### PR TITLE
To avoid sqlite's limitation ( max 64 charactor of index name ), remove ...

### DIFF
--- a/db/migrate/20110918161853_rename_series_statement_manifestation_id_to_root_manifestation_id.rb
+++ b/db/migrate/20110918161853_rename_series_statement_manifestation_id_to_root_manifestation_id.rb
@@ -1,9 +1,13 @@
 class RenameSeriesStatementManifestationIdToRootManifestationId < ActiveRecord::Migration
   def self.up
+    remove_index :series_statements, :series_statement_identifier
     rename_column :series_statements, :manifestation_id, :root_manifestation_id
+    add_index :series_statements, :series_statement_identifier
   end
 
   def self.down
+    remove_index :series_statements, :series_statement_identifier
     rename_column :series_statements, :root_manifestation_id, :manifestation_id
+    add_index :series_statements, :series_statement_identifier
   end
 end


### PR DESCRIPTION
To avoid sqlite's limitation ( max 64 charactor of index name ), remove and re-create series_statement_identifier index on series_statements table when up/down db migration #20110918161853 .

Using current enju_leaf git tree with sqlite3 database backend, rake db:migrate fails because of 'Too long index name'.

<pre>
$ rake db:migrate
...
==  RenameSeriesStatementManifestationIdToRootManifestationId: migrating ======
-- rename_column(:series_statements, :manifestation_id, :root_manifestation_id)
rake aborted!
An error has occurred, this and all later migrations canceled:

Index name 'temp_index_altered_series_statements_on_series_statement_identifier' on table 'altered_series_statements' is too long; the limit is 64 characters
...
</pre>


Modified database migrate script of version #20110918161853 to remove and re-create series_statement_identifier index. 
