### PR TITLE
Width mismatch on Edit-user and -my_account

### DIFF
--- a/app/assets/stylesheets/enju.css
+++ b/app/assets/stylesheets/enju.css
@@ -377,6 +377,7 @@ input.year_field, input.month_field, input.day_field{
 }
 
 input.date_field{
+  width: 20em;
   ime-mode: disabled;
 }
 


### PR DESCRIPTION
Width of date_field are too wide especially in the case of Edit UI of users and my_account.
it should limit to 20em at least.
