### PR TITLE
Fixed 'New produce' submenu of /produces links wrong path of /realized/new

### DIFF
--- a/app/views/produces/_index.html.erb
+++ b/app/views/produces/_index.html.erb
@@ -30,7 +30,7 @@
 <div id="submenu" class="ui-corner-all">
   <%- if can? :create, Produce -%>
     <ul>
-      <li><%= link_to t('page.new', :model => t('activerecord.models.produce')), new_realize_path -%></li>
+      <li><%= link_to t('page.new', :model => t('activerecord.models.produce')), new_produce_path -%></li>
     </ul>
   <%- end -%>
 </div>


### PR DESCRIPTION
On url /produces/ it shows index of produce and 'new produce' submenu, however it points wrong path of 'new realize' function. I fixed view file of that.
