### PR TITLE
Fix a list element mismatch.

### DIFF
--- a/app/views/manifestations/show.html.erb
+++ b/app/views/manifestations/show.html.erb
@@ -55,7 +55,7 @@
       <%- unless @manifestation.carrier_type.name == 'file' -%>
         <% if defined?(EnjuCirculation) %>
           <% if @manifestation.is_reservable_by?(current_user) %>
-            <li><%= link_to_reservation(@manifestation, @reserve) %></li>
+            <li><%= link_to_reservation(@manifestation, @reserve) %>
             <br />
             (<%= t('page.number_of_reservations', :count => @reserved_count) -%>)</li>
           <%- else -%>


### PR DESCRIPTION
高久です。

<li>要素の終了タグの入れ子が2重に書かれている状態でしたので、直しました。

どうぞよろしくお願いします。
