### PR TITLE
replace \Z with \z in regular expressions

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -14,9 +14,9 @@ class Profile < ActiveRecord::Base
   validates_associated :user_group, :library
   validates_associated :user
   validates_presence_of :user_group, :library, :locale #, :user_number
-  validates :user_number, uniqueness: true, format: { with: /\A[0-9A-Za-z_]+\Z/ }, allow_blank: true
+  validates :user_number, uniqueness: true, format: { with: /\A[0-9A-Za-z_]+\z/ }, allow_blank: true
   validates :user_id, uniqueness: true, allow_blank: true
-  validates :birth_date, format: { with: /\A\d{4}-\d{1,2}-\d{1,2}\Z/ }, allow_blank: true
+  validates :birth_date, format: { with: /\A\d{4}-\d{1,2}-\d{1,2}\z/ }, allow_blank: true
 
   strip_attributes only: :user_number
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,6 +1,6 @@
 class Role < ActiveRecord::Base
   include MasterModel
-  validates :name, presence: true, format: { with: /\A[A-Za-z][a-z_,]*[a-z]\Z/ }
+  validates :name, presence: true, format: { with: /\A[A-Za-z][a-z_,]*[a-z]\z/ }
   has_many :user_has_roles
   has_many :users, through: :user_has_roles
   after_save :clear_all_cache

--- a/lib/enju_leaf/master_model.rb
+++ b/lib/enju_leaf/master_model.rb
@@ -26,7 +26,7 @@ module MasterModel
 
     private
     def valid_name?
-      unless name =~ /\A[a-z][0-9a-z_]*[0-9a-z]\Z/
+      unless name =~ /\A[a-z][0-9a-z_]*[0-9a-z]\z/
         errors.add(:name, I18n.t('page.only_lowercase_letters_and_numbers_are_allowed'))
       end
     end

--- a/lib/enju_leaf/user.rb
+++ b/lib/enju_leaf/user.rb
@@ -37,7 +37,7 @@ module EnjuLeaf
         accepts_nested_attributes_for :user_has_role
 
         validates :username, presence: true, uniqueness: true, format: {
-          with: /\A[0-9A-Za-z][0-9A-Za-z_\-]*[0-9A-Za-z]\Z/
+          with: /\A[0-9A-Za-z][0-9A-Za-z_\-]*[0-9A-Za-z]\z/
         }
         validates :email, format: Devise::email_regexp, allow_blank: true, uniqueness: true
         validates_date :expired_at, allow_blank: true

--- a/lib/generators/enju_leaf/setup/setup_generator.rb
+++ b/lib/generators/enju_leaf/setup/setup_generator.rb
@@ -59,7 +59,7 @@ EOS
         ""
     end
     gsub_file 'config/routes.rb', /devise_for :users$/, "devise_for :users, skip: [:registration]"
-    gsub_file 'config/initializers/devise.rb', '# config.email_regexp = /\A[^@]+@[^@]+\z/', 'config.email_regexp = /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\Z/i'
+    gsub_file 'config/initializers/devise.rb', '# config.email_regexp = /\A[^@]+@[^@]+\z/', 'config.email_regexp = /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i'
     gsub_file 'config/initializers/devise.rb', '# config.authentication_keys = [:email]', 'config.authentication_keys = [:username]'
     gsub_file 'config/initializers/devise.rb', '# config.secret_key', 'config.secret_key'
 


### PR DESCRIPTION
文字列の末尾という意図と思われる箇所で，`\z`（文字列末尾）でなく `\Z`（文字列末尾または文字列末尾の改行の直前）が使われています。
おそらく `\z` の誤記だろうと思います。