### PR TITLE
Fix width of book jacket overflows from sidebar

### DIFF
--- a/app/assets/stylesheets/enju_leaf/enju.css
+++ b/app/assets/stylesheets/enju_leaf/enju.css
@@ -530,6 +530,8 @@ div.book_jacket{
 
 div.book_jacket img.book_jacket{
   border: 1px solid rgba(0, 0, 0, 0.25);
+  box-sizing: border-box;
+  max-width: 100%;
 }
 
 div.search_form{


### PR DESCRIPTION
書影の取得元に openBD を設定した場合に、`/manifestations/:id` で書影がサイドバー領域から溢れて表示される問題の修正です