### PR TITLE
Show commit hash in system information if gem installed from git

### DIFF
--- a/app/views/page/system_information.html.erb
+++ b/app/views/page/system_information.html.erb
@@ -8,7 +8,13 @@
     <li>Gems:
     <ul>
       <% @specs.sort_by{|e| e.name }.each do |spec| %>
-        <li><%= spec.name %>: <%= spec.version.to_s %></li>
+        <li>
+          <%= spec.name %>: <%= spec.version.to_s %>
+          <% if spec.source.is_a? Bundler::Source::Git %>
+            from <%= spec.source.uri %>
+            (at <%= spec.source.options['revision'].slice(0..7) %>)
+          <% end %>
+        </li>
       <% end %>
     </ul>
     </li>


### PR DESCRIPTION
![「システムの基本的な情報の表示」ページのスクリーンショット](https://user-images.githubusercontent.com/92577/59151781-07033180-8a74-11e9-83c5-2b6f74b1e318.png)

「システムの基本的な情報の表示」ページ (`/page/system_information`) に表示されるバージョン番号について、GemがGitからインストールされている場合にはリポジトリのURLとコミットのハッシュを表示する修正です。