### PR TITLE
エクスポート時の通知メッセージで図書館名が正しく表示されていない

### DIFF
--- a/app/views/event_export_mailer/completed.en.text.erb
+++ b/app/views/event_export_mailer/completed.en.text.erb
@@ -5,5 +5,5 @@ Created at: <%= @event_export_file.created_at %>
 Detail: <%= event_export_file_url(@event_export_file) %>
 
 --  
-<%= @library_group.display_name %>
+<%= @library_group.display_name.localize %>
 <%= root_url %>

--- a/app/views/event_export_mailer/completed.ja.text.erb
+++ b/app/views/event_export_mailer/completed.ja.text.erb
@@ -5,5 +5,5 @@ ID: <%= @event_export_file.id %>
 詳細: <%= event_export_file_url(@event_export_file) %>
 
 --  
-<%= @library_group.display_name %>
+<%= @library_group.display_name.localize %>
 <%= root_url %>

--- a/app/views/event_export_mailer/failed.en.text.erb
+++ b/app/views/event_export_mailer/failed.en.text.erb
@@ -5,5 +5,5 @@ Created at: <%= @event_export_file.created_at %>
 Detail: <%= event_export_file_url(@event_export_file) %>
 
 --  
-<%= @library_group.display_name %>
+<%= @library_group.display_name.localize %>
 <%= root_url %>

--- a/app/views/event_export_mailer/failed.ja.text.erb
+++ b/app/views/event_export_mailer/failed.ja.text.erb
@@ -5,5 +5,5 @@ ID: <%= @event_export_file.id %>
 詳細: <%= event_export_file_url(@event_export_file) %>
 
 --  
-<%= @library_group.display_name %>
+<%= @library_group.display_name.localize %>
 <%= root_url %>

--- a/app/views/resource_export_mailer/completed.en.text.erb
+++ b/app/views/resource_export_mailer/completed.en.text.erb
@@ -5,5 +5,5 @@ Created at: <%= @resource_export_file.created_at %>
 Detail: <%= resource_export_file_url(@resource_export_file) %>
 
 --  
-<%= @library_group.display_name %>
+<%= @library_group.display_name.localize %>
 <%= root_url %>

--- a/app/views/resource_export_mailer/completed.ja.text.erb
+++ b/app/views/resource_export_mailer/completed.ja.text.erb
@@ -5,5 +5,5 @@ ID: <%= @resource_export_file.id %>
 詳細: <%= resource_export_file_url(@resource_export_file) %>
 
 --  
-<%= @library_group.display_name %>
+<%= @library_group.display_name.localize %>
 <%= root_url %>

--- a/app/views/resource_export_mailer/failed.en.text.erb
+++ b/app/views/resource_export_mailer/failed.en.text.erb
@@ -5,5 +5,5 @@ Created at: <%= @resource_export_file.created_at %>
 Detail: <%= resource_export_file_url(@resource_export_file) %>
 
 --  
-<%= @library_group.display_name %>
+<%= @library_group.display_name.localize %>
 <%= root_url %>

--- a/app/views/resource_export_mailer/failed.ja.text.erb
+++ b/app/views/resource_export_mailer/failed.ja.text.erb
@@ -5,5 +5,5 @@ ID: <%= @resource_export_file.id %>
 詳細: <%= resource_export_file_url(@resource_export_file) %>
 
 --  
-<%= @library_group.display_name %>
+<%= @library_group.display_name.localize %>
 <%= root_url %>

--- a/app/views/user_export_mailer/completed.en.text.erb
+++ b/app/views/user_export_mailer/completed.en.text.erb
@@ -5,5 +5,5 @@ Created at: <%= @user_export_file.created_at %>
 Detail: <%= user_export_file_url(@user_export_file) %>
 
 --  
-<%= @library_group.display_name %>
+<%= @library_group.display_name.localize %>
 <%= root_url %>

--- a/app/views/user_export_mailer/completed.ja.text.erb
+++ b/app/views/user_export_mailer/completed.ja.text.erb
@@ -5,5 +5,5 @@ ID: <%= @user_export_file.id %>
 詳細: <%= user_export_file_url(@user_export_file) %>
 
 --  
-<%= @library_group.display_name %>
+<%= @library_group.display_name.localize %>
 <%= root_url %>

--- a/app/views/user_export_mailer/failed.en.text.erb
+++ b/app/views/user_export_mailer/failed.en.text.erb
@@ -5,5 +5,5 @@ Created at: <%= @user_export_file.created_at %>
 Detail: <%= user_export_file_url(@user_export_file) %>
 
 --  
-<%= @library_group.display_name %>
+<%= @library_group.display_name.localize %>
 <%= root_url %>

--- a/app/views/user_export_mailer/failed.ja.text.erb
+++ b/app/views/user_export_mailer/failed.ja.text.erb
@@ -5,5 +5,5 @@ ID: <%= @user_export_file.id %>
 詳細: <%= user_export_file_url(@user_export_file) %>
 
 --  
-<%= @library_group.display_name %>
+<%= @library_group.display_name.localize %>
 <%= root_url %>

--- a/spec/fixtures/library_groups.yml
+++ b/spec/fixtures/library_groups.yml
@@ -2,7 +2,7 @@
 one:
   id: 1
   name: enju
-  display_name: えんじゅ図書館
+  display_name: Enju Library
   short_name: Enju
   note: 
   my_networks: 0.0.0.0/0

--- a/spec/fixtures/library_groups.yml
+++ b/spec/fixtures/library_groups.yml
@@ -1,9 +1,9 @@
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
 one:
   id: 1
-  name: unknown
-  display_name: unknown
-  short_name: unknown
+  name: enju
+  display_name: えんじゅ図書館
+  short_name: Enju
   note: 
   my_networks: 0.0.0.0/0
   url: "http://localhost:3000/"

--- a/spec/mailers/event_export_mailer_spec.rb
+++ b/spec/mailers/event_export_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe EventExportMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/event_export_mailer_spec.rb
+++ b/spec/mailers/event_export_mailer_spec.rb
@@ -1,5 +1,10 @@
 require "rails_helper"
 
 RSpec.describe EventExportMailer, type: :mailer do
-  pending "add some examples to (or delete) #{__FILE__}"
+  fixtures :all
+
+  it "should send completed mail" do
+    mailer = EventExportMailer.completed(event_export_files(:event_export_file_00001))
+    expect(mailer.body).to match(/^えんじゅ図書館\r\n/)
+  end
 end

--- a/spec/mailers/event_export_mailer_spec.rb
+++ b/spec/mailers/event_export_mailer_spec.rb
@@ -5,6 +5,6 @@ RSpec.describe EventExportMailer, type: :mailer do
 
   it "should send completed mail" do
     mailer = EventExportMailer.completed(event_export_files(:event_export_file_00001))
-    expect(mailer.body).to match(/^えんじゅ図書館\r\n/)
+    expect(mailer.body.to_s).to match(/^Enju Library\n/)
   end
 end

--- a/spec/mailers/previews/event_export_mailer_preview.rb
+++ b/spec/mailers/previews/event_export_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/event_export_mailer
+class EventExportMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/previews/resource_export_mailer_preview.rb
+++ b/spec/mailers/previews/resource_export_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/resource_export_mailer
+class ResourceExportMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/previews/user_export_mailer_preview.rb
+++ b/spec/mailers/previews/user_export_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_export_mailer
+class UserExportMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/resource_export_mailer_spec.rb
+++ b/spec/mailers/resource_export_mailer_spec.rb
@@ -5,6 +5,6 @@ RSpec.describe ResourceExportMailer, type: :mailer do
 
   it "should send completed mail" do
     mailer = ResourceExportMailer.completed(resource_export_files(:resource_export_file_00001))
-    expect(mailer.body).to match(/^えんじゅ図書館\r\n/)
+    expect(mailer.body.to_s).to match(/^Enju Library\n/)
   end
 end

--- a/spec/mailers/resource_export_mailer_spec.rb
+++ b/spec/mailers/resource_export_mailer_spec.rb
@@ -1,5 +1,10 @@
 require "rails_helper"
 
 RSpec.describe ResourceExportMailer, type: :mailer do
-  pending "add some examples to (or delete) #{__FILE__}"
+  fixtures :all
+
+  it "should send completed mail" do
+    mailer = ResourceExportMailer.completed(resource_export_files(:resource_export_file_00001))
+    expect(mailer.body).to match(/^えんじゅ図書館\r\n/)
+  end
 end

--- a/spec/mailers/resource_export_mailer_spec.rb
+++ b/spec/mailers/resource_export_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe ResourceExportMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/user_export_mailer_spec.rb
+++ b/spec/mailers/user_export_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe UserExportMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/user_export_mailer_spec.rb
+++ b/spec/mailers/user_export_mailer_spec.rb
@@ -5,6 +5,6 @@ RSpec.describe UserExportMailer, type: :mailer do
 
   it "should send completed mail" do
     mailer = UserExportMailer.completed(user_export_files(:user_export_file_00001))
-    expect(mailer.body).to match(/^えんじゅ図書館\r\n/)
+    expect(mailer.body.to_s).to match(/^Enju Library\n/)
   end
 end

--- a/spec/mailers/user_export_mailer_spec.rb
+++ b/spec/mailers/user_export_mailer_spec.rb
@@ -1,5 +1,10 @@
 require "rails_helper"
 
 RSpec.describe UserExportMailer, type: :mailer do
-  pending "add some examples to (or delete) #{__FILE__}"
+  fixtures :all
+
+  it "should send completed mail" do
+    mailer = UserExportMailer.completed(user_export_files(:user_export_file_00001))
+    expect(mailer.body).to match(/^えんじゅ図書館\r\n/)
+  end
 end


### PR DESCRIPTION
資料・催し物・ユーザのエクスポート時の通知メッセージでは、図書館名は各言語での名称のみが表示されることを意図していますが、1.3.6では正しく表示されていません。このため、各言語での名称のみを表示するように修正しています。
![image](https://user-images.githubusercontent.com/11428/163708950-d5a4ac87-8c4b-4227-aec7-1133934046de.png)
