### PR TITLE
資料形態のアイコンが登録されていない場合、既定のアイコンを表示するよう変更

### DIFF
--- a/app/helpers/enju_biblio/application_helper.rb
+++ b/app/helpers/enju_biblio/application_helper.rb
@@ -2,8 +2,7 @@ module EnjuBiblio
   module ApplicationHelper
     def form_icon(carrier_type)
       unless carrier_type
-        image_tag('icons/help.png', size: '16x16', class: 'enju_icon', alt: t('page.unknown'))
-        return
+        return image_tag('icons/help.png', size: '16x16', class: 'enju_icon', alt: t('page.unknown'))
       end
 
       if carrier_type.attachment.present?

--- a/app/helpers/enju_biblio/application_helper.rb
+++ b/app/helpers/enju_biblio/application_helper.rb
@@ -1,9 +1,16 @@
 module EnjuBiblio
   module ApplicationHelper
     def form_icon(carrier_type)
-      image_tag(carrier_type_path(carrier_type, format: :download), size: '16x16', class: 'enju_icon', alt: carrier_type.display_name.localize)
-    rescue NoMethodError
-      image_tag('icons/help.png', size: '16x16', class: 'enju_icon', alt: t('page.unknown'))
+      unless carrier_type
+        image_tag('icons/help.png', size: '16x16', class: 'enju_icon', alt: t('page.unknown'))
+        return
+      end
+
+      if carrier_type.attachment.present?
+        image_tag(carrier_type_path(carrier_type, format: :download), size: '16x16', class: 'enju_icon', alt: carrier_type.display_name.localize)
+      else
+        image_tag('icons/help.png', size: '16x16', class: 'enju_icon', alt: carrier_type.display_name.localize)
+      end
     end
 
     def content_type_icon(content_type)

--- a/spec/helpers/enju_biblio/application_helper_spec.rb
+++ b/spec/helpers/enju_biblio/application_helper_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe EnjuBiblio::ApplicationHelper do
+  fixtures :all
+
+  it "should render form_icon if carrier_type is nil" do
+    expect(helper.form_icon(nil)).to match /src=\"\/assets\/icons\/help-/
+  end
+
+  it "should render form_icon if carrier_type's attachment is blank " do
+    expect(helper.form_icon(FactoryBot.create(:carrier_type))).to match /src=\"\/assets\/icons\/help-/
+  end
+end


### PR DESCRIPTION
#1565 の対応です。既定で`help.png`を表示するようにしています。
https://github.com/next-l/enju_leaf/blob/main/app/assets/images/icons/help.png