### PR TITLE
ユーザ一括更新TSVでpassword列が空の場合、パスワードをリセットしないように修正

### DIFF
--- a/app/models/user_import_file.rb
+++ b/app/models/user_import_file.rb
@@ -83,6 +83,13 @@ class UserImportFile < ApplicationRecord
         end
         new_user.username = username
         new_user.assign_attributes(set_user_params(row))
+
+        if row['password'].to_s.strip.present?
+          new_user.password = row['password']
+        else
+          new_user.password = Devise.friendly_token[0..7]
+        end
+
         profile = Profile.new
         profile.assign_attributes(set_profile_params(row))
 
@@ -152,6 +159,7 @@ class UserImportFile < ApplicationRecord
       new_user = User.find_by(username: username)
       if new_user.try(:profile)
         new_user.assign_attributes(set_user_params(row))
+        new_user.password = row['password'] if row['password'].to_s.strip.present?
         new_user.profile.assign_attributes(set_profile_params(row))
         Profile.transaction do
           if new_user.save && new_user.profile.save
@@ -266,12 +274,6 @@ class UserImportFile < ApplicationRecord
   def set_user_params(row)
     params = {}
     params[:email] = row['email'] if row['email'].present?
-
-    if row['password'].present?
-      params[:password] = row['password']
-    else
-      params[:password] = Devise.friendly_token[0..7]
-    end
 
     if %w(t true).include?(row['locked'].to_s.downcase.strip)
       params[:locked] = '1'

--- a/spec/fixtures/files/user_update_file4.tsv
+++ b/spec/fixtures/files/user_update_file4.tsv
@@ -1,2 +1,3 @@
-username	locked
-user001	TRUE
+username	locked	password
+user001	TRUE	testpassword
+librarian1	FALSE	

--- a/spec/models/user_import_file_spec.rb
+++ b/spec/models/user_import_file_spec.rb
@@ -178,6 +178,22 @@ describe UserImportFile do
       user001 = User.where(username: 'user001').first
       user001.access_locked?.should be_truthy
     end
+
+    it "should update user's password" do
+      file = UserImportFile.create!(
+        user_import: fixture_file_upload("user_update_file4.tsv"),
+        user: users(:admin),
+        default_user_group: UserGroup.find(2),
+        default_library: Library.find(3)
+      )
+      result = file.modify
+      result.should have_key(:user_updated)
+      user001 = User.find_by(username: 'user001')
+      user001.access_locked?.should be_truthy
+      expect(user001.valid_password?('testpassword')).to be_truthy
+      user002 = User.find_by(username: 'librarian1')
+      expect(user002.valid_password?('librarian1password')).to be_truthy
+    end
   end
 
   describe "when its mode is 'destroy'" do


### PR DESCRIPTION
#1543 の修正です。