### PR TITLE
ファセット表示の上下の間隔を調整

### DIFF
--- a/app/assets/stylesheets/enju.css
+++ b/app/assets/stylesheets/enju.css
@@ -570,3 +570,8 @@ div.search_form{
 img.enju_icon {
   vertical-align: middle;
 }
+
+h4.facet-header {
+  margin-top: 1em;
+  margin-bottom: 0em;
+}

--- a/app/views/manifestations/_carrier_type_facet.html.erb
+++ b/app/views/manifestations/_carrier_type_facet.html.erb
@@ -1,4 +1,4 @@
-<h4><%= t('activerecord.models.carrier_type') -%></h4>
+<h4 class="facet-header"><%= t('activerecord.models.carrier_type') -%></h4>
 <ul>
   <%- @carrier_type_facet.each do |facet| -%>
     <li><%= carrier_type_facet(facet) %></li>

--- a/app/views/manifestations/_export_list.html.erb
+++ b/app/views/manifestations/_export_list.html.erb
@@ -1,4 +1,4 @@
-<h4><%= t('page.other_format') %></h4>
+<h4 class="facet-header"><%= t('page.other_format') %></h4>
 <ul>
   <li><%= link_to 'RDF/XML', url_for(request.params.merge(format: :rdf, only_path: true)) %>
   <li><%= link_to 'MODS', url_for(request.params.merge(format: :mods, only_path: true)) %></li>

--- a/app/views/manifestations/_language_facet.html.erb
+++ b/app/views/manifestations/_language_facet.html.erb
@@ -1,4 +1,4 @@
-<h4><%= t('activerecord.models.language') -%></h4>
+<h4 class="facet-header"><%= t('activerecord.models.language') -%></h4>
 <ul>
   <%- languages = params[:language].to_s.split -%>
   <%- current_languages = languages.dup -%>

--- a/app/views/manifestations/_library_facet.html.erb
+++ b/app/views/manifestations/_library_facet.html.erb
@@ -1,4 +1,4 @@
-<h4><%= t('activerecord.models.library') -%></h4>
+<h4 class="facet-header"><%= t('activerecord.models.library') -%></h4>
 <ul>
   <%- libraries = params[:library].to_s.split -%>
   <%- @library_facet.each do |facet| -%>

--- a/app/views/manifestations/_pub_year_facet.html.erb
+++ b/app/views/manifestations/_pub_year_facet.html.erb
@@ -1,4 +1,4 @@
-<h4><%= t('activerecord.attributes.manifestation.date_of_publication') -%></h4>
+<h4 class="facet-header"><%= t('activerecord.attributes.manifestation.date_of_publication') -%></h4>
 <ul>
   <%- @pub_year_facet.each do |facet| -%>
     <li>

--- a/app/views/manifestations/_reservable_facet.html.erb
+++ b/app/views/manifestations/_reservable_facet.html.erb
@@ -1,4 +1,4 @@
-<h4><%= t('manifestation.reservable') -%></h4>
+<h4 class="facet-header"><%= t('manifestation.reservable') -%></h4>
 <ul>
   <%- @reservable_facet.each do |facet| -%>
     <% facet.value ? facet_reservable = true : facet_reservable = false %>

--- a/app/views/manifestations/_subject_facet.html.erb
+++ b/app/views/manifestations/_subject_facet.html.erb
@@ -1,4 +1,4 @@
-<h4><%= t('activerecord.models.subject') -%></h4>
+<h4 class="facet-header"><%= t('activerecord.models.subject') -%></h4>
 <%- unless @subject_facet.blank? -%>
 <ul>
   <%- @subject_facet[0..19].each do |facet| -%>


### PR DESCRIPTION
ファセット表示の上下の間隔を調整するPRです。 https://github.com/next-l/enju_leaf/issues/1059#issuecomment-166585861 で指摘のあった、以下の問題を修正しています。

> ただ、少なくとも、今のは、くっつきすぎてて変なのと、予約のフィルタとまぎらわしいからなんとかしたい。

修正前後の表示の例を以下に示します。

現状:
![image](https://user-images.githubusercontent.com/11428/164973923-7b80a617-abdc-4b13-88b4-d1a48e6baa44.png)

修正後:
![image](https://user-images.githubusercontent.com/11428/164973909-054c3027-ebf2-4fa9-b999-662e42a4ac8d.png)
