### PR TITLE
deleted_atカラムを削除

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -301,7 +301,6 @@ end
 #  full_name_alternative               :text
 #  created_at                          :datetime
 #  updated_at                          :datetime
-#  deleted_at                          :datetime
 #  zip_code_1                          :string
 #  zip_code_2                          :string
 #  address_1                           :text

--- a/app/models/bookstore.rb
+++ b/app/models/bookstore.rb
@@ -26,7 +26,6 @@ end
 #  fax_number       :string
 #  url              :string
 #  position         :integer
-#  deleted_at       :datetime
 #  created_at       :datetime
 #  updated_at       :datetime
 #

--- a/app/models/concerns/enju_seed/enju_user.rb
+++ b/app/models/concerns/enju_seed/enju_user.rb
@@ -290,7 +290,6 @@ end
 #  authentication_token     :string(255)
 #  created_at               :datetime        not null
 #  updated_at               :datetime        not null
-#  deleted_at               :datetime
 #  username                 :string(255)     not null
 #  library_id               :integer         default(1), not null
 #  user_group_id            :integer         default(1), not null

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -116,7 +116,6 @@ end
 #  start_at          :datetime
 #  end_at            :datetime
 #  all_day           :boolean          default(FALSE), not null
-#  deleted_at        :datetime
 #  display_name      :text
 #  created_at        :datetime
 #  updated_at        :datetime

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -157,7 +157,6 @@ end
 #  item_identifier         :string
 #  created_at              :datetime
 #  updated_at              :datetime
-#  deleted_at              :datetime
 #  shelf_id                :integer          default(1), not null
 #  include_supplements     :boolean          default(FALSE), not null
 #  note                    :text

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -102,7 +102,6 @@ end
 #  country_id            :integer
 #  created_at            :datetime
 #  updated_at            :datetime
-#  deleted_at            :datetime
 #  opening_hour          :text
 #  isil                  :string
 #  latitude              :float

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -112,7 +112,6 @@ class Manifestation < ApplicationRecord
     end
     time :created_at
     time :updated_at
-    time :deleted_at
     time :pub_date, multiple: true do
       if series_master?
         root_series_statement.root_manifestation.pub_dates

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -723,7 +723,6 @@ end
 #  date_copyrighted                :datetime
 #  created_at                      :datetime
 #  updated_at                      :datetime
-#  deleted_at                      :datetime
 #  access_address                  :string
 #  language_id                     :integer          default(1), not null
 #  carrier_type_id                 :integer          default(1), not null

--- a/app/models/reserve.rb
+++ b/app/models/reserve.rb
@@ -334,7 +334,6 @@ end
 #  updated_at                   :datetime
 #  canceled_at                  :datetime
 #  expired_at                   :datetime
-#  deleted_at                   :datetime
 #  expiration_notice_to_patron  :boolean          default(FALSE)
 #  expiration_notice_to_library :boolean          default(FALSE)
 #  pickup_location_id           :integer

--- a/app/models/shelf.rb
+++ b/app/models/shelf.rb
@@ -61,6 +61,5 @@ end
 #  position     :integer
 #  created_at   :datetime
 #  updated_at   :datetime
-#  deleted_at   :datetime
 #  closed       :boolean          default(FALSE), not null
 #

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -33,7 +33,6 @@ end
 #  lock_version            :integer          default(0), not null
 #  created_at              :datetime
 #  updated_at              :datetime
-#  deleted_at              :datetime
 #  url                     :string
 #  manifestation_id        :integer
 #  subject_heading_type_id :integer

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -31,7 +31,6 @@ end
 #  note             :text
 #  user_id          :integer
 #  order_list_id    :integer
-#  deleted_at       :datetime
 #  subscribes_count :integer          default(0), not null
 #  created_at       :datetime
 #  updated_at       :datetime

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,6 @@ end
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  username               :string
-#  deleted_at             :datetime
 #  expired_at             :datetime
 #  failed_attempts        :integer          default(0)
 #  unlock_token           :string

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -21,7 +21,6 @@ end
 #  position                         :integer
 #  created_at                       :datetime
 #  updated_at                       :datetime
-#  deleted_at                       :datetime
 #  valid_period_for_new_user        :integer          default(0), not null
 #  expired_at                       :datetime
 #  number_of_day_to_notify_overdue  :integer          default(0), not null

--- a/config/locales/enju_biblio_en.yml
+++ b/config/locales/enju_biblio_en.yml
@@ -58,7 +58,6 @@ en:
         manifestation_identifier: Local manifestation identifier
         date_of_publication: Date of publication
         pub_date: Date of publication
-        deleted_at: Deleted at
         access_address: Access address
         number_of_page_string: Number of page (string)
         start_page: Start page
@@ -118,7 +117,6 @@ en:
       item:
         call_number: Call number
         item_identifier: Item identifier
-        deleted_at: Deleted at
         include_supplements: Include supplements
         note: Note
         memo: Memo
@@ -148,7 +146,6 @@ en:
         full_name: Full name
         full_name_transcription: Full name transcription
         full_name_alternative: Full name alternative
-        deleted_at: Deleted at
         zip_code_1: Zip code 1
         zip_code_2: Zip code 2
         address_1: Address 1

--- a/config/locales/enju_biblio_ja.yml
+++ b/config/locales/enju_biblio_ja.yml
@@ -58,7 +58,6 @@ ja:
         manifestation_identifier: ローカル識別子
         date_of_publication: 出版日
         pub_date: 出版日
-        deleted_at: 削除時刻
         access_address: アクセスアドレス
         number_of_page_string: ページ数（文字列）
         start_page: 最初のページ
@@ -118,7 +117,6 @@ ja:
       item:
         call_number: 請求記号
         item_identifier: 所蔵情報ID
-        deleted_at: 削除時刻
         include_supplements: 付録を含む
         note: 注記
         memo: 業務メモ
@@ -148,7 +146,6 @@ ja:
         full_name: フルネーム
         full_name_transcription: フルネーム（ヨミ）
         full_name_alternative: フルネーム（代替）
-        deleted_at: 削除時刻
         zip_code_1: 郵便番号1
         zip_code_2: 郵便番号2
         address_1: 住所1

--- a/config/locales/enju_circulation_en.yml
+++ b/config/locales/enju_circulation_en.yml
@@ -43,7 +43,6 @@ en:
         checked_out_at: Checked out at
         canceled_at: Canceled at
         expired_at: Expired at
-        deleted_at: Deleted at
         created_at: Reserved at
         retained_at: Retained at
         postponed_at: Postponed at

--- a/config/locales/enju_circulation_ja.yml
+++ b/config/locales/enju_circulation_ja.yml
@@ -41,7 +41,6 @@ ja:
         checked_out_at: 貸出時刻
         canceled_at: 取消時刻
         expired_at: 有効期限（この日以降は不要）
-        deleted_at: 削除時刻
         created_at: 予約時刻
         retained_at: 確保時刻
         postponed_at: 取置取消時刻

--- a/config/locales/enju_event_en.yml
+++ b/config/locales/enju_event_en.yml
@@ -19,7 +19,6 @@ en:
         note: Note
         start_at: Start at
         end_at: End at
-        deleted_at: Deleted at
         all_day: All day
         display_name: Display name
       event_import_file:

--- a/config/locales/enju_event_ja.yml
+++ b/config/locales/enju_event_ja.yml
@@ -19,7 +19,6 @@ ja:
         note: 注記
         start_at: 開始時刻
         end_at: 終了時刻
-        deleted_at: 削除時刻
         all_day: 終日
         display_name: 表示名
       event_import_file:

--- a/config/locales/enju_leaf_en.yml
+++ b/config/locales/enju_leaf_en.yml
@@ -21,7 +21,6 @@ en:
         email_confirmation: Email (confirmation)
         crypted_password: Crypted password
         salt: Salt
-        deleted_at: Deleted at
         remember_token: Remember token
         remember_token_expires_at: Remember token expires at
         activation_code: Activation code
@@ -56,7 +55,6 @@ en:
         display_name: Display name
         note: Note
         position: Position
-        deleted_at: Deleted at
         valid_period_for_new_user: Valid period for new user
         number_of_day_to_notify_due_date: Number of day to notify due date
         number_of_day_to_notify_overdue: Number of day to notify overdue

--- a/config/locales/enju_leaf_ja.yml
+++ b/config/locales/enju_leaf_ja.yml
@@ -21,7 +21,6 @@ ja:
         email_confirmation: メールアドレス（確認）
         crypted_password: 暗号化パスワード
         salt: ソルト
-        deleted_at: 削除時刻
         remember_token: 覚えているトークン
         remember_token_expires_at: トークンを忘れないで期限が切れる
         activation_code: 活性化コード
@@ -56,7 +55,6 @@ ja:
         display_name: 表示名
         note: 注記
         position: 位置
-        deleted_at: 削除時刻
         valid_period_for_new_user: 新規ユーザの有効日数
         number_of_day_to_notify_due_date: 貸出期限の何日前に督促を送るか
         number_of_day_to_notify_overdue: 貸出期限の何日後に督促を送るか

--- a/config/locales/enju_library_en.yml
+++ b/config/locales/enju_library_en.yml
@@ -32,7 +32,6 @@ en:
         call_number_rows: Call number rows
         call_number_delimiter: Call number delimiter
         position: Position
-        deleted_at: Deleted at
         opening_hour: Opening hour
         isil: ISIL
         address: Address
@@ -41,7 +40,6 @@ en:
         display_name: Display name
         note: Note
         position: Position
-        deleted_at: Deleted at
         closed: Closed
       library_group:
         name: Name
@@ -70,7 +68,6 @@ en:
         fax_number: Fax number
         url: URL
         position: Position
-        deleted_at: Deleted at
       budget_type:
         name: Name
         display_name: Display name
@@ -83,7 +80,6 @@ en:
       subscription:
         title: Title
         note: Note
-        deleted_at: Deleted at
         subscribes_count: Count
       request_status_type:
         name: Name

--- a/config/locales/enju_library_ja.yml
+++ b/config/locales/enju_library_ja.yml
@@ -32,7 +32,6 @@ ja:
         call_number_rows: 請求記号の列数
         call_number_delimiter: 請求番号の区切り文字
         position: 位置
-        deleted_at: 削除時刻
         opening_hour: 開館時間
         isil: ISIL
         address: 住所
@@ -41,7 +40,6 @@ ja:
         display_name: 表示名
         note: 注記
         position: 位置
-        deleted_at: 削除時刻
         closed: 閉架
       library_group:
         name: 名前
@@ -70,7 +68,6 @@ ja:
         fax_number: ファックス番号
         url: URL
         position: 位置
-        deleted_at: 削除時刻
       budget_type:
         name: 名称
         display_name: 表示名
@@ -83,7 +80,6 @@ ja:
       subscription:
         title: タイトル
         note: 注記
-        deleted_at: 削除時刻
         subscribes_count: 購読数
       request_status_type:
         name: 名前

--- a/db/migrate/20220507153151_remove_deleted_at_from_tables.rb
+++ b/db/migrate/20220507153151_remove_deleted_at_from_tables.rb
@@ -1,0 +1,8 @@
+class RemoveDeletedAtFromTables < ActiveRecord::Migration[6.1]
+  def change
+    %i(agents manifestations items subjects reserves libraries shelves
+    user_groups events bookstores subscriptions users ).each do |table|
+      remove_column table, :deleted_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_25_090703) do
+ActiveRecord::Schema.define(version: 2022_05_07_153151) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -126,7 +126,6 @@ ActiveRecord::Schema.define(version: 2020_10_25_090703) do
     t.text "full_name_alternative"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.datetime "deleted_at"
     t.string "zip_code_1"
     t.string "zip_code_2"
     t.text "address_1"
@@ -232,7 +231,6 @@ ActiveRecord::Schema.define(version: 2020_10_25_090703) do
     t.string "fax_number"
     t.string "url"
     t.integer "position"
-    t.datetime "deleted_at"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -544,7 +542,6 @@ ActiveRecord::Schema.define(version: 2020_10_25_090703) do
     t.datetime "start_at"
     t.datetime "end_at"
     t.boolean "all_day", default: false, null: false
-    t.datetime "deleted_at"
     t.text "display_name"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -697,7 +694,6 @@ ActiveRecord::Schema.define(version: 2020_10_25_090703) do
     t.string "item_identifier"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.datetime "deleted_at"
     t.integer "shelf_id", default: 1, null: false
     t.boolean "include_supplements", default: false, null: false
     t.text "note"
@@ -771,7 +767,6 @@ ActiveRecord::Schema.define(version: 2020_10_25_090703) do
     t.integer "country_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.datetime "deleted_at"
     t.text "opening_hour"
     t.string "isil"
     t.float "latitude"
@@ -933,7 +928,6 @@ ActiveRecord::Schema.define(version: 2020_10_25_090703) do
     t.datetime "date_copyrighted"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.datetime "deleted_at"
     t.string "access_address"
     t.integer "language_id", default: 1, null: false
     t.integer "carrier_type_id", default: 1, null: false
@@ -1262,7 +1256,6 @@ ActiveRecord::Schema.define(version: 2020_10_25_090703) do
     t.datetime "updated_at"
     t.datetime "canceled_at"
     t.datetime "expired_at"
-    t.datetime "deleted_at"
     t.boolean "expiration_notice_to_patron", default: false
     t.boolean "expiration_notice_to_library", default: false
     t.integer "pickup_location_id"
@@ -1419,7 +1412,6 @@ ActiveRecord::Schema.define(version: 2020_10_25_090703) do
     t.integer "position"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.datetime "deleted_at"
     t.boolean "closed", default: false, null: false
     t.index ["library_id"], name: "index_shelves_on_library_id"
   end
@@ -1454,7 +1446,6 @@ ActiveRecord::Schema.define(version: 2020_10_25_090703) do
     t.integer "lock_version", default: 0, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.datetime "deleted_at"
     t.string "url"
     t.integer "manifestation_id"
     t.integer "subject_heading_type_id"
@@ -1482,7 +1473,6 @@ ActiveRecord::Schema.define(version: 2020_10_25_090703) do
     t.text "note"
     t.integer "user_id"
     t.integer "order_list_id"
-    t.datetime "deleted_at"
     t.integer "subscribes_count", default: 0, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -1603,7 +1593,6 @@ ActiveRecord::Schema.define(version: 2020_10_25_090703) do
     t.integer "position"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.datetime "deleted_at"
     t.integer "valid_period_for_new_user", default: 0, null: false
     t.datetime "expired_at"
     t.integer "number_of_day_to_notify_overdue", default: 0, null: false
@@ -1697,7 +1686,6 @@ ActiveRecord::Schema.define(version: 2020_10_25_090703) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "username"
-    t.datetime "deleted_at"
     t.datetime "expired_at"
     t.integer "failed_attempts", default: 0
     t.string "unlock_token"

--- a/spec/factories/agents.rb
+++ b/spec/factories/agents.rb
@@ -30,7 +30,6 @@ end
 #  full_name_alternative               :text
 #  created_at                          :datetime
 #  updated_at                          :datetime
-#  deleted_at                          :datetime
 #  zip_code_1                          :string
 #  zip_code_2                          :string
 #  address_1                           :text

--- a/spec/factories/bookstores.rb
+++ b/spec/factories/bookstores.rb
@@ -17,7 +17,6 @@ end
 #  fax_number       :string
 #  url              :string
 #  position         :integer
-#  deleted_at       :datetime
 #  created_at       :datetime
 #  updated_at       :datetime
 #

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -20,7 +20,6 @@ end
 #  start_at          :datetime
 #  end_at            :datetime
 #  all_day           :boolean          default(FALSE), not null
-#  deleted_at        :datetime
 #  display_name      :text
 #  created_at        :datetime
 #  updated_at        :datetime

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -20,7 +20,6 @@ end
 #  item_identifier         :string
 #  created_at              :datetime
 #  updated_at              :datetime
-#  deleted_at              :datetime
 #  shelf_id                :integer          default(1), not null
 #  include_supplements     :boolean          default(FALSE), not null
 #  note                    :text

--- a/spec/factories/libraries.rb
+++ b/spec/factories/libraries.rb
@@ -36,7 +36,6 @@ end
 #  country_id            :integer
 #  created_at            :datetime
 #  updated_at            :datetime
-#  deleted_at            :datetime
 #  opening_hour          :text
 #  isil                  :string
 #  latitude              :float

--- a/spec/factories/manifestations.rb
+++ b/spec/factories/manifestations.rb
@@ -27,7 +27,6 @@ end
 #  date_copyrighted                :datetime
 #  created_at                      :datetime
 #  updated_at                      :datetime
-#  deleted_at                      :datetime
 #  access_address                  :string
 #  language_id                     :integer          default(1), not null
 #  carrier_type_id                 :integer          default(1), not null

--- a/spec/factories/reserves.rb
+++ b/spec/factories/reserves.rb
@@ -28,7 +28,6 @@ end
 #  updated_at                   :datetime
 #  canceled_at                  :datetime
 #  expired_at                   :datetime
-#  deleted_at                   :datetime
 #  expiration_notice_to_patron  :boolean          default(FALSE)
 #  expiration_notice_to_library :boolean          default(FALSE)
 #  pickup_location_id           :integer

--- a/spec/factories/shelves.rb
+++ b/spec/factories/shelves.rb
@@ -18,6 +18,5 @@ end
 #  position     :integer
 #  created_at   :datetime
 #  updated_at   :datetime
-#  deleted_at   :datetime
 #  closed       :boolean          default(FALSE), not null
 #

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -22,7 +22,6 @@ end
 #  lock_version            :integer          default(0), not null
 #  created_at              :datetime
 #  updated_at              :datetime
-#  deleted_at              :datetime
 #  url                     :string
 #  manifestation_id        :integer
 #  subject_heading_type_id :integer

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -14,7 +14,6 @@ end
 #  note             :text
 #  user_id          :integer
 #  order_list_id    :integer
-#  deleted_at       :datetime
 #  subscribes_count :integer          default(0), not null
 #  created_at       :datetime
 #  updated_at       :datetime

--- a/spec/factories/user_groups.rb
+++ b/spec/factories/user_groups.rb
@@ -15,7 +15,6 @@ end
 #  position                         :integer
 #  created_at                       :datetime
 #  updated_at                       :datetime
-#  deleted_at                       :datetime
 #  valid_period_for_new_user        :integer          default(0), not null
 #  expired_at                       :datetime
 #  number_of_day_to_notify_overdue  :integer          default(0), not null

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -55,7 +55,6 @@ end
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  username               :string
-#  deleted_at             :datetime
 #  expired_at             :datetime
 #  failed_attempts        :integer          default(0)
 #  unlock_token           :string

--- a/spec/fixtures/agents.yml
+++ b/spec/fixtures/agents.yml
@@ -290,7 +290,6 @@ agent_00202:
 #  full_name_alternative               :text
 #  created_at                          :datetime
 #  updated_at                          :datetime
-#  deleted_at                          :datetime
 #  zip_code_1                          :string
 #  zip_code_2                          :string
 #  address_1                           :text

--- a/spec/fixtures/bookstores.yml
+++ b/spec/fixtures/bookstores.yml
@@ -83,7 +83,6 @@ bookstore_00007:
 #  fax_number       :string
 #  url              :string
 #  position         :integer
-#  deleted_at       :datetime
 #  created_at       :datetime
 #  updated_at       :datetime
 #

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -5,7 +5,6 @@ event_00001:
   end_at: 2008-01-14 02:54:00 +09:00
   name: 仕事始め
   display_name: 仕事始め
-  deleted_at: 
   start_at: 2008-01-13 02:54:00 +09:00
   id: 1
   note: なんとかかんとか
@@ -17,7 +16,6 @@ event_00002:
   end_at: 2008-01-14 02:54:00 +09:00
   name: テスト
   display_name: テスト
-  deleted_at: 
   start_at: 2008-01-13 02:54:00 +09:00
   id: 2
   note: テスト用のイベントです。
@@ -29,7 +27,6 @@ event_00003:
   end_at: 2008-02-05 00:00:00 +09:00
   name: ミーティング
   display_name: ミーティング
-  deleted_at: 
   start_at: 2008-01-13 00:00:00 +09:00
   id: 3
   note: ""
@@ -41,7 +38,6 @@ event_00004:
   end_at: 2008-02-06 00:00:00 +09:00
   name: テスト
   display_name: テスト
-  deleted_at: 
   start_at: 2008-02-05 00:00:00 +09:00
   id: 4
   note: なんとかかんとか
@@ -53,7 +49,6 @@ event_00005:
   end_at: 2008-02-08 00:00:00 +09:00
   name: test
   display_name: test
-  deleted_at: 
   start_at: 2008-02-05 00:00:00 +09:00
   id: 5
   note: ""
@@ -65,7 +60,6 @@ event_00006:
   end_at: 2008-02-08 00:00:00 +09:00
   name: なんとかかんとか
   display_name: なんとかかんとか
-  deleted_at: 
   start_at: 2008-02-05 00:00:00 +09:00
   id: 6
   note: ""
@@ -77,7 +71,6 @@ event_00007:
   end_at: 2008-02-08 00:00:00 +09:00
   name: test
   display_name: test
-  deleted_at: 
   start_at: 2008-02-05 00:00:00 +09:00
   id: 7
   note: test
@@ -89,7 +82,6 @@ event_00008:
   end_at: 2008-02-05 15:00:00 +09:00
   name: test
   display_name: test
-  deleted_at: 
   start_at: 2008-02-05 15:00:00 +09:00
   id: 8
   note: test

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -108,7 +108,6 @@ event_00008:
 #  start_at          :datetime
 #  end_at            :datetime
 #  all_day           :boolean          default(FALSE), not null
-#  deleted_at        :datetime
 #  display_name      :text
 #  created_at        :datetime
 #  updated_at        :datetime

--- a/spec/fixtures/items.yml
+++ b/spec/fixtures/items.yml
@@ -297,7 +297,6 @@ item_00026:
 #  item_identifier         :string
 #  created_at              :datetime
 #  updated_at              :datetime
-#  deleted_at              :datetime
 #  shelf_id                :integer          default(1), not null
 #  include_supplements     :boolean          default(FALSE), not null
 #  note                    :text

--- a/spec/fixtures/libraries.yml
+++ b/spec/fixtures/libraries.yml
@@ -93,7 +93,6 @@ library_00004:
 #  country_id            :integer
 #  created_at            :datetime
 #  updated_at            :datetime
-#  deleted_at            :datetime
 #  opening_hour          :text
 #  isil                  :string
 #  latitude              :float

--- a/spec/fixtures/manifestations.yml
+++ b/spec/fixtures/manifestations.yml
@@ -1849,7 +1849,6 @@ manifestation_00218:
 #  date_copyrighted                :datetime
 #  created_at                      :datetime
 #  updated_at                      :datetime
-#  deleted_at                      :datetime
 #  access_address                  :string
 #  language_id                     :integer          default(1), not null
 #  carrier_type_id                 :integer          default(1), not null

--- a/spec/fixtures/reserves.yml
+++ b/spec/fixtures/reserves.yml
@@ -153,7 +153,6 @@ reserve_00015:
 #  updated_at                   :datetime
 #  canceled_at                  :datetime
 #  expired_at                   :datetime
-#  deleted_at                   :datetime
 #  expiration_notice_to_patron  :boolean          default(FALSE)
 #  expiration_notice_to_library :boolean          default(FALSE)
 #  pickup_location_id           :integer

--- a/spec/fixtures/shelves.yml
+++ b/spec/fixtures/shelves.yml
@@ -41,7 +41,6 @@ shelf_00004:
 #  position     :integer
 #  created_at   :datetime
 #  updated_at   :datetime
-#  deleted_at   :datetime
 #  closed       :boolean          default(FALSE), not null
 #
 

--- a/spec/fixtures/subjects.yml
+++ b/spec/fixtures/subjects.yml
@@ -72,7 +72,6 @@ subject_00005:
 #  lock_version            :integer          default(0), not null
 #  created_at              :datetime
 #  updated_at              :datetime
-#  deleted_at              :datetime
 #  url                     :string
 #  manifestation_id        :integer
 #  subject_heading_type_id :integer

--- a/spec/fixtures/subscriptions.yml
+++ b/spec/fixtures/subscriptions.yml
@@ -19,7 +19,6 @@ subscription_00002:
 #  note             :text
 #  user_id          :integer
 #  order_list_id    :integer
-#  deleted_at       :datetime
 #  subscribes_count :integer          default(0), not null
 #  created_at       :datetime
 #  updated_at       :datetime

--- a/spec/fixtures/user_groups.yml
+++ b/spec/fixtures/user_groups.yml
@@ -41,7 +41,6 @@ user_group_00003:
 #  position                         :integer
 #  created_at                       :datetime
 #  updated_at                       :datetime
-#  deleted_at                       :datetime
 #  valid_period_for_new_user        :integer          default(0), not null
 #  expired_at                       :datetime
 #  number_of_day_to_notify_overdue  :integer          default(0), not null

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -63,7 +63,6 @@ user4:
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  username               :string
-#  deleted_at             :datetime
 #  expired_at             :datetime
 #  failed_attempts        :integer          default(0)
 #  unlock_token           :string

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -87,7 +87,6 @@ end
 #  full_name_alternative               :text
 #  created_at                          :datetime
 #  updated_at                          :datetime
-#  deleted_at                          :datetime
 #  zip_code_1                          :string
 #  zip_code_2                          :string
 #  address_1                           :text

--- a/spec/models/bookstore_spec.rb
+++ b/spec/models/bookstore_spec.rb
@@ -18,7 +18,6 @@ end
 #  fax_number       :string
 #  url              :string
 #  position         :integer
-#  deleted_at       :datetime
 #  created_at       :datetime
 #  updated_at       :datetime
 #

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -47,7 +47,6 @@ end
 #  item_identifier         :string
 #  created_at              :datetime
 #  updated_at              :datetime
-#  deleted_at              :datetime
 #  shelf_id                :integer          default(1), not null
 #  include_supplements     :boolean          default(FALSE), not null
 #  note                    :text

--- a/spec/models/library_spec.rb
+++ b/spec/models/library_spec.rb
@@ -37,7 +37,6 @@ end
 #  country_id            :integer
 #  created_at            :datetime
 #  updated_at            :datetime
-#  deleted_at            :datetime
 #  opening_hour          :text
 #  isil                  :string
 #  latitude              :float

--- a/spec/models/manifestation_spec.rb
+++ b/spec/models/manifestation_spec.rb
@@ -276,7 +276,6 @@ end
 #  date_copyrighted                :datetime
 #  created_at                      :datetime
 #  updated_at                      :datetime
-#  deleted_at                      :datetime
 #  access_address                  :string
 #  language_id                     :integer          default(1), not null
 #  carrier_type_id                 :integer          default(1), not null

--- a/spec/models/reserve_spec.rb
+++ b/spec/models/reserve_spec.rb
@@ -142,7 +142,6 @@ end
 #  updated_at                   :datetime
 #  canceled_at                  :datetime
 #  expired_at                   :datetime
-#  deleted_at                   :datetime
 #  expiration_notice_to_patron  :boolean          default(FALSE)
 #  expiration_notice_to_library :boolean          default(FALSE)
 #  pickup_location_id           :integer

--- a/spec/models/shelf_spec.rb
+++ b/spec/models/shelf_spec.rb
@@ -22,6 +22,5 @@ end
 #  position     :integer
 #  created_at   :datetime
 #  updated_at   :datetime
-#  deleted_at   :datetime
 #  closed       :boolean          default(FALSE), not null
 #

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -17,7 +17,6 @@ end
 #  note             :text
 #  user_id          :integer
 #  order_list_id    :integer
-#  deleted_at       :datetime
 #  subscribes_count :integer          default(0), not null
 #  created_at       :datetime
 #  updated_at       :datetime

--- a/spec/models/user_group_spec.rb
+++ b/spec/models/user_group_spec.rb
@@ -27,7 +27,6 @@ end
 #  position                         :integer
 #  created_at                       :datetime
 #  updated_at                       :datetime
-#  deleted_at                       :datetime
 #  valid_period_for_new_user        :integer          default(0), not null
 #  expired_at                       :datetime
 #  number_of_day_to_notify_overdue  :integer          default(0), not null

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -140,7 +140,6 @@ end
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  username               :string
-#  deleted_at             :datetime
 #  expired_at             :datetime
 #  failed_attempts        :integer          default(0)
 #  unlock_token           :string


### PR DESCRIPTION
deleted_atカラムは、もともと論理削除機能のために存在していました。しかし、論理削除機能は使用しなくなって長期間たっており、また今後も論理削除機能は実装しないため、このカラムを削除します。