### PR TITLE
get_versionメソッドを削除

### DIFF
--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -4,7 +4,6 @@ class AgentsController < ApplicationController
   before_action :get_work, :get_expression, :get_manifestation, :get_item, :get_agent, except: [:update, :destroy]
   before_action :get_agent_merge_list, except: [:create, :update, :destroy]
   before_action :prepare_options, only: [:new, :edit]
-  before_action :get_version, only: [:show]
 
   # GET /agents
   # GET /agents.json

--- a/app/controllers/concerns/enju_library/controller.rb
+++ b/app/controllers/concerns/enju_library/controller.rb
@@ -172,11 +172,6 @@ module EnjuLibrary
       end
     end
 
-    def get_version
-      @version = params[:version_id].to_i if params[:version_id]
-      @version = nil if @version == 0
-    end
-
     def clear_search_sessions
       session[:query] = nil
       session[:params] = nil

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,7 +6,6 @@ class ItemsController < ApplicationController
   before_action :get_inventory_file
   before_action :get_library, :get_item, except: [:create, :update, :destroy]
   before_action :prepare_options, only: [:new, :edit]
-  before_action :get_version, only: [:show]
   after_action :convert_charset, only: :index
 
   # GET /items

--- a/app/controllers/manifestations_controller.rb
+++ b/app/controllers/manifestations_controller.rb
@@ -10,7 +10,6 @@ class ManifestationsController < ApplicationController
   before_action :get_series_statement, only: [:index, :new, :edit]
   before_action :get_item, :get_libraries, only: :index
   before_action :prepare_options, only: [:new, :edit]
-  before_action :get_version, only: [:show]
   after_action :convert_charset, only: :index
 
   # GET /manifestations


### PR DESCRIPTION
https://github.com/next-l/enju_leaf/pull/1644 で編集履歴の保存機能を削除しましたが、履歴情報の取得のメソッドが残っていたため、削除します。