### PR TITLE
マニュアルのURLを1.4のものに更新

### DIFF
--- a/db/fixtures/enju_library/library_group/translations.yml
+++ b/db/fixtures/enju_library/library_group/translations.yml
@@ -1,12 +1,12 @@
 library_group_00001_translations_ja:
   locale: ja
   login_banner: オープンソース図書館システム Next-L Enju です。このメッセージは管理者としてログインした後に変更することができます。
-  footer_banner: "[Next-L Enju Leaf __VERSION__](https://github.com/next-l/enju_leaf), オープンソース統合図書館システム | [このシステムについて](/page/about) | [不具合を報告する](https://github.com/next-l/enju_leaf/issues) | [マニュアル](https://next-l.github.io/manual/1.3/)<br/>\r\n\
+  footer_banner: "[Next-L Enju Leaf __VERSION__](https://github.com/next-l/enju_leaf), オープンソース統合図書館システム | [このシステムについて](/page/about) | [不具合を報告する](https://github.com/next-l/enju_leaf/issues) | [マニュアル](https://next-l.github.io/manual/1.4/)<br/>\r\n\
     Developed by [Kosuke Tanabe](https://github.com/nabeta) and [Project Next-L](https://www.next-l.jp)."
   library_group_id: 1
 library_group_00001_translations_en:
   locale: en
   login_banner: Next-L Enju, an open-source integrated library system. You can edit this message after logging in as Administrator.
-  footer_banner: "[Next-L Enju Leaf __VERSION__](https://github.com/next-l/enju_leaf), an open source integrated library system | [About this system](/page/about) | [Report bugs](https://github.com/next-l/enju_leaf/issues) | [Manual](https://next-l.github.io/manual/1.3/)<br/>\r\n\
+  footer_banner: "[Next-L Enju Leaf __VERSION__](https://github.com/next-l/enju_leaf), an open source integrated library system | [About this system](/page/about) | [Report bugs](https://github.com/next-l/enju_leaf/issues) | [Manual](https://next-l.github.io/manual/1.4/)<br/>\r\n\
     Developed by [Kosuke Tanabe](https://github.com/nabeta) and [Project Next-L](https://www.next-l.jp)."
   library_group_id: 1


### PR DESCRIPTION
#1674 の修正です。

フッターの情報はDBに書き込まれているため、この変更は新規インストールのときにしか反映されません。すでにインストール済みの場合、図書館全体の設定から変更することになります。
https://enju.next-l.jp/library_groups/1/edit