### PR TITLE
add config.i18n.available_locales

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,9 @@ module EnjuLeaf
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
-    config.i18n.default_locale = (ENV['ENJU_LEAF_DEFAULT_LOCALE'] || 'en').to_sym
+    default_locale = (ENV['ENJU_LEAF_DEFAULT_LOCALE'] || 'en').to_sym
+    config.i18n.default_locale = default_locale
+    config.i18n.available_locales = [default_locale, :en]
     config.time_zone = ENV['ENJU_LEAF_TIME_ZONE'] || 'UTC'
 
     base_url = URI.parse(ENV['ENJU_LEAF_BASE_URL'] || 'http://localhost:3000')

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,7 @@ module EnjuLeaf
     # the framework and any gems in your application.
     default_locale = (ENV['ENJU_LEAF_DEFAULT_LOCALE'] || 'en').to_sym
     config.i18n.default_locale = default_locale
-    config.i18n.available_locales = [default_locale, :en]
+    config.i18n.available_locales = [default_locale, :ja, :en].uniq
     config.time_zone = ENV['ENJU_LEAF_TIME_ZONE'] || 'UTC'
 
     base_url = URI.parse(ENV['ENJU_LEAF_BASE_URL'] || 'http://localhost:3000')


### PR DESCRIPTION
config.i18n.available_localesの設定を追加し、英語と既定のロケールのみを有効化します。これは rails-i18n gem の追加 #1671 で、他の言語のロケールファイルが読み込まれるようになったことによるものです。

fix #1690 