### PR TITLE
Add delivery method

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -117,5 +117,5 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
-  config.action_mailer.delivery_method = ENV['ENJU_LEAF_ACTION_MAILER_DELIVERY_METHOD'].to_sym
+  config.action_mailer.delivery_method = (ENV['ENJU_LEAF_ACTION_MAILER_DELIVERY_METHOD'] || 'test').to_sym
 end


### PR DESCRIPTION
環境変数`ENJU_LEAF_ACTION_MAILER_DELIVERY_METHOD`を追加しました。Action Mailerの`delivery_method`を指定できるようにしています。既定値は`test`で、実際にメールを送信するには`smtp`に変更します。  
https://railsguides.jp/action_mailer_basics.html#action-mailer%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%99%E3%82%8B

fix #1694 