### PR TITLE
個別資料の貸出一覧のRSSとTSVのリンクを修正

### DIFF
--- a/app/views/checkouts/_index_item.html.erb
+++ b/app/views/checkouts/_index_item.html.erb
@@ -18,12 +18,12 @@
 <div id="submenu" class="ui-corner-all ui-widget-content">
   <ul>
     <li>
-      <%= link_to 'RSS', item_checkouts_path(item, format: :rss) -%>
-      <%= link_to image_tag('icons/feed.png', size: '16x16', class: 'enju_icon', alt: 'RSS'), item_checkouts_path(item, format: :rss) -%>
+      <%= link_to 'RSS', checkouts_path(item_id: item.id, format: :rss) -%>
+      <%= link_to image_tag('icons/feed.png', size: '16x16', class: 'enju_icon', alt: 'RSS'), checkouts_path(item_id: item.id, format: :rss) -%>
     </li>
     <li>
-      <%= link_to 'TSV', item_checkouts_path(item, format: :txt, locale: @locale.to_s) -%>
-      <%= link_to image_tag('icons/page_white_excel.png', size: '16x16', class: 'enju_icon', alt: 'TSV'), item_checkouts_path(item, format: :txt, locale: @locale.to_s) -%>
+      <%= link_to 'TSV', checkouts_path(item_id: item.id, format: :txt, locale: @locale.to_s) -%>
+      <%= link_to image_tag('icons/page_white_excel.png', size: '16x16', class: 'enju_icon', alt: 'TSV'), checkouts_path(item_id: item.id, format: :txt, locale: @locale.to_s) -%>
     </li>
   </ul>
 </div>

--- a/spec/system/checkouts_spec.rb
+++ b/spec/system/checkouts_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe 'Checkouts', type: :system do
       expect(page).to have_content checkouts(:checkout_00001).user.username
       expect(page).to have_content checkouts(:checkout_00001).user.profile.user_number
     end
+
+    it 'should get checkouts with item_id' do
+      sign_in users(:librarian1)
+      visit checkouts_path(item_id: 1)
+      expect(page).to have_content checkouts(:checkout_00001).user.username
+      expect(page).to have_content checkouts(:checkout_00001).user.profile.user_number
+    end
   end
 
   describe 'When not logged in', solr: true do


### PR DESCRIPTION
個別資料の個別の画面で、貸出一覧のRSSとTSVのリンクがエラーになっていたのを修正しています。
fix #1700 