### PR TITLE
relocate the RSS feed link under total_count

### DIFF
--- a/app/views/manifestations/index.html.erb
+++ b/app/views/manifestations/index.html.erb
@@ -99,9 +99,6 @@
     <%= render 'submenu_parent' %>
   <% end %>
   <h3><%= link_to h("#{t('page.total')}: #{@count[:query_result]}"), url_for(request.params.merge(action: 'index', view: nil, carrier_type: nil, library: nil, language: nil, subject: nil, only_path: true))  -%></h3>
-    <%- if @manifestations.total_count > 0 -%>
-      <%= render 'manifestations/all_facet' -%>
-    <%- end -%>
   <div>
     <%- if params[:library_id].blank? -%>
       <%= link_to((image_tag 'icons/feed.png', size: '16x16', alt: t('page.feed'), class: 'enju_icon'), url_for(request.params.merge(format: :rss, page: nil, library_id: nil, only_path: true))) -%> <%= link_to t('page.search_result_feed'), url_for(request.params.merge(format: :rss, page: nil, library_id: nil, commit: nil, only_path: true)) -%>
@@ -109,6 +106,10 @@
       <%= link_to((image_tag 'icons/feed.png', size: '16x16', alt: t('page.feed'), class: 'enju_icon'), url_for(request.params.merge(format: :rss, page: nil, only_path: true))) -%> <%= link_to t('page.search_result_feed'), url_for(request.params.merge(format: :rss, page: nil, commit: nil, only_path: true)) -%>
     <%- end -%>
   </div>
+
+  <%- if @manifestations.total_count > 0 -%>
+    <%= render 'manifestations/all_facet' -%>
+  <%- end -%>
   <%= render 'manifestations/export_list' %>
 </div>
 


### PR DESCRIPTION
検索画面のRSSフィードのリンクを、合計ヒット数の直下に移動しました。
![image](https://user-images.githubusercontent.com/11428/174471025-977e1cd6-a469-4b4c-bef7-6a3f9fcbb18f.png)

fix #1059 