### PR TITLE
一部のIdentifierの項目のヘッダー名を修正

### DIFF
--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -604,6 +604,8 @@ class Manifestation < ApplicationRecord
     }
 
     IdentifierType.find_each do |type|
+      next if ['issn', 'isbn', 'jpno', 'ncid'].include?(type.name.downcase.strip)
+
       record[:"identifier:#{type.name.to_sym}"] = identifiers.where(identifier_type: type).pluck(:body).join('//')
     end
 
@@ -644,13 +646,8 @@ class Manifestation < ApplicationRecord
       end
     end
 
-    if defined?(EnjuNdl)
-      record["jpno"] = identifier_contents(:jpno).first
-    end
-
-    if defined?(EnjuNii)
-      record["ncid"] = identifier_contents(:ncid).first
-    end
+    record["jpno"] = identifier_contents(:jpno).first
+    record["ncid"] = identifier_contents(:ncid).first
 
     record
   end

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -604,7 +604,7 @@ class Manifestation < ApplicationRecord
     }
 
     IdentifierType.find_each do |type|
-      next if ['issn', 'isbn', 'jpno', 'ncid'].include?(type.name.downcase.strip)
+      next if ['issn', 'isbn', 'jpno', 'ncid', 'lccn', 'doi'].include?(type.name.downcase.strip)
 
       record[:"identifier:#{type.name.to_sym}"] = identifiers.where(identifier_type: type).pluck(:body).join('//')
     end
@@ -648,6 +648,9 @@ class Manifestation < ApplicationRecord
 
     record["jpno"] = identifier_contents(:jpno).first
     record["ncid"] = identifier_contents(:ncid).first
+    record["lccn"] = identifier_contents(:lccn).first
+    record["doi"] = identifier_contents(:doi).first
+    record["iss_itemno"] = identifier_contents(:iss_itemno).first
 
     record
   end

--- a/db/fixtures/enju_biblio/identifier_types.yml
+++ b/db/fixtures/enju_biblio/identifier_types.yml
@@ -22,15 +22,15 @@ identifier_type_00003:
   id: 3
 
 identifier_type_00004:
-  name: doi
-  display_name: DOI
+  name: ncid
+  display_name: NCID
   note: 
   position: 4
   id: 4
 
 identifier_type_00005:
-  name: iss_itemno
-  display_name: NDL Search
+  name: lccn
+  display_name: LCCN
   note: 
   position: 5
   id: 5
@@ -42,16 +42,30 @@ identifier_type_00006:
   position: 6
   id: 6
 
+identifier_type_00006:
+  name: doi
+  display_name: DOI
+  note: 
+  position: 6
+  id: 6
+
+identifier_type_00007:
+  name: iss_itemno
+  display_name: NDL Search
+  note: 
+  position: 7
+  id: 7
+
 # == Schema Information
 #
 # Table name: identifier_types
 #
 #  id           :integer          not null, primary key
-#  name         :string(255)
+#  name         :string
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
+#  created_at   :datetime
+#  updated_at   :datetime
 #
 

--- a/spec/fixtures/identifier_types.yml
+++ b/spec/fixtures/identifier_types.yml
@@ -1,39 +1,60 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/Fixtures.html
 
-one:
+identifier_type_00001:
   name: isbn
   display_name: ISBN
   note: 
   position: 1
   id: 1
 
-two:
+identifier_type_00002:
   name: issn
   display_name: ISSN
   note: 
   position: 2
   id: 2
 
-three:
+identifier_type_00003:
   name: jpno
   display_name: JPNO
   note: 
   position: 3
   id: 3
 
-four:
+identifier_type_00004:
   name: ncid
   display_name: NCID
   note: 
   position: 4
   id: 4
 
-five:
-  name: custom
-  display_name: 独自識別子
+identifier_type_00005:
+  name: lccn
+  display_name: LCCN
   note: 
   position: 5
   id: 5
+
+identifier_type_00006:
+  name: lccn
+  display_name: LCCN
+  note: 
+  position: 6
+  id: 6
+
+identifier_type_00006:
+  name: doi
+  display_name: DOI
+  note: 
+  position: 6
+  id: 6
+
+identifier_type_00007:
+  name: iss_itemno
+  display_name: NDL Search
+  note: 
+  position: 7
+  id: 7
 
 # == Schema Information
 #
@@ -47,3 +68,4 @@ five:
 #  created_at   :datetime
 #  updated_at   :datetime
 #
+

--- a/spec/fixtures/identifiers.yml
+++ b/spec/fixtures/identifiers.yml
@@ -109,6 +109,16 @@ identifier_00001a:
   identifier_type_id: 5
   body: "custom1111"
 
+identifier_00002a:
+  manifestation_id: 2
+  identifier_type_id: 3
+  body: "20792291"
+
+identifier_00004a:
+  manifestation_id: 4
+  identifier_type_id: 6
+  body: "2001024898"
+
 # == Schema Information
 #
 # Table name: identifiers

--- a/spec/models/manifestation_spec.rb
+++ b/spec/models/manifestation_spec.rb
@@ -170,6 +170,9 @@ describe Manifestation, solr: true do
       expect(csv["ncid"].compact).not_to be_empty
       expect(csv["lccn"].compact).not_to be_empty
       # expect(csv["doi"].compact).not_to be_empty
+      expect(csv["identifier:jpno"].compact).to be_empty
+      expect(csv["identifier:ncid"].compact).to be_empty
+      expect(csv["identifier:lccn"].compact).to be_empty
     end
 
     it "should export edition fields" do
@@ -212,6 +215,7 @@ describe Manifestation, solr: true do
       csv = CSV.parse(lines, headers: true, col_sep: "\t")
       m = csv.find{|row| row["manifestation_id"].to_i == manifestation.id }
       expect(m["isbn"].split('//').sort).to eq ['9784043898039', '9784840239219']
+      expect(m["identifier:isbn"]).to be_nil
     end
 
     it "should respect the role of the user" do

--- a/spec/models/manifestation_spec.rb
+++ b/spec/models/manifestation_spec.rb
@@ -166,6 +166,10 @@ describe Manifestation, solr: true do
       expect(csv["item_price"].compact.first).to eq nil
       expect(csv["library"].compact.first).to eq "web"
       expect(csv["shelf"].compact.first).to eq "web"
+      expect(csv["jpno"].compact).not_to be_empty
+      expect(csv["ncid"].compact).not_to be_empty
+      expect(csv["lccn"].compact).not_to be_empty
+      # expect(csv["doi"].compact).not_to be_empty
     end
 
     it "should export edition fields" do
@@ -207,7 +211,7 @@ describe Manifestation, solr: true do
       lines = Manifestation.export()
       csv = CSV.parse(lines, headers: true, col_sep: "\t")
       m = csv.find{|row| row["manifestation_id"].to_i == manifestation.id }
-      expect(m["identifier:isbn"].split('//').sort).to eq ['9784043898039', '9784840239219']
+      expect(m["isbn"].split('//').sort).to eq ['9784043898039', '9784840239219']
     end
 
     it "should respect the role of the user" do


### PR DESCRIPTION
資料TSVのエクスポートの際、一部のIdentifier項目が重複してエクスポートされており、このTSVを使用したインポートの際にエラーを起こしていました。
https://github.com/next-l/enju_leaf/issues/1571#issuecomment-904239297

このPRでは、以下のIdentifierの項目について、後者のみを表示するようにしています。

- identifier:isbn / isbn
- identifier:issn / issn
- identifier:jpno / jpno
- identifier:doi / doi
- identifier:iss_itemno / iss_itemno
- identifier:lccn / lccn
- identifier:ncid / ncid