### PR TITLE
貸出延長画面の貸出詳細へのリンクのラベルを「貸出の表示」に変更

### DIFF
--- a/app/views/checkouts/edit.html.erb
+++ b/app/views/checkouts/edit.html.erb
@@ -52,7 +52,7 @@
 <div id="submenu" class="ui-corner-all ui-widget-content">
   <%= render 'manifestations/book_jacket', manifestation: @checkout.item.manifestation if @checkout.item -%>
   <ul>
-    <li><%= link_to t('page.show'), @checkout -%></li>
+    <li><%= link_to t('page.showing', model: t('activerecord.models.checkout')), @checkout -%></li>
     <% if @checkout.user %>
       <li><%= link_to t('page.back'), :back -%></li>
     <% end %>

--- a/spec/system/checkouts_spec.rb
+++ b/spec/system/checkouts_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe 'Checkouts', type: :system do
       expect(page).to have_content checkouts(:checkout_00001).user.profile.user_number
     end
 
+    it 'should edit checkout' do
+      sign_in users(:librarian1)
+      visit edit_checkout_path(checkouts(:checkout_00001))
+      expect(page).to have_content '貸出の表示'
+    end
+
     it 'should get checkouts with item_id' do
       sign_in users(:librarian1)
       visit checkouts_path(item_id: 1)


### PR DESCRIPTION
#994 の修正です。