### PR TITLE
IIIFサーバのCantaloupeを追加

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,6 @@ module EnjuLeaf
       protocol: base_url.scheme,
       port: base_url.port
     }
+    config.hosts << 'web'
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,6 @@ module EnjuLeaf
       protocol: base_url.scheme,
       port: base_url.port
     }
-    config.hosts << 'web'
+    config.hosts += ['web', '127.0.0.1']
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
       SOURCE_STATIC: HttpSource
       HTTPSOURCE_BASICLOOKUPSTRATEGY_URL_PREFIX: http://web:3000/picture_files/
       HTTPSOURCE_BASICLOOKUPSTRATEGY_URL_SUFFIX: '.download'
-      ENDPOINT_API_ENABLED: true
+      ENDPOINT_API_ENABLED: 'true'
     networks:
       internal:
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,10 +128,26 @@ services:
       timeout: 20s
       retries: 3
 
+  cantaloupe:
+    image: uclalibrary/cantaloupe:5.0.5-1
+    expose:
+      - 8182
+    restart: always
+    environment:
+      no_proxy: web
+      SOURCE_STATIC: HttpSource
+      HTTPSOURCE_BASICLOOKUPSTRATEGY_URL_PREFIX: http://web:3000/picture_files/
+      HTTPSOURCE_BASICLOOKUPSTRATEGY_URL_SUFFIX: '.download'
+    networks:
+      internal:
+    depends_on:
+      - nginx
+
   nginx:
     image: nginx:stable
     ports:
       - 8080:80
+      - 8182:8182
     volumes:
       - ./nginx/templates:/etc/nginx/templates:ro
       - ./public:/opt/enju_leaf/public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,14 +134,20 @@ services:
       - 8182
     restart: always
     environment:
-      no_proxy: web
+      no_proxy: localhost,web
       SOURCE_STATIC: HttpSource
       HTTPSOURCE_BASICLOOKUPSTRATEGY_URL_PREFIX: http://web:3000/picture_files/
       HTTPSOURCE_BASICLOOKUPSTRATEGY_URL_SUFFIX: '.download'
+      ENDPOINT_API_ENABLED: true
     networks:
       internal:
     depends_on:
       - nginx
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8182/health"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
 
   nginx:
     image: nginx:stable

--- a/nginx/templates/cantaloupe.conf.template
+++ b/nginx/templates/cantaloupe.conf.template
@@ -1,0 +1,16 @@
+server {
+  listen 8182;
+  server_name _;
+
+  location / {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Forwarded-Path /;
+    proxy_redirect http://cantaloupe:8182/ /;
+    if ($request_uri ~* "/(.*)") {
+      proxy_pass http://cantaloupe:8182;
+    }
+  }
+}


### PR DESCRIPTION
IIIFサーバのCantaloupeを追加するPRです。
https://cantaloupe-project.github.io/

以下のDockerイメージを利用しています。`docker compose up`で他のコンテナと同時に起動するようになっています。
https://hub.docker.com/r/uclalibrary/cantaloupe

- Cantaloupeへの外部からのアクセスは、リバースプロキシのnginxを経由するようにしている。使用するポートはCantaloupeの既定と同じ 8182/tcp
- Cantaloupeには以下の設定を追加している
    ```
      # アプリケーション間の通信にプロキシを使用しない
      no_proxy: localhost,web
      # 画像の取得にhttpを使用。詳細はマニュアルを参照
      # https://cantaloupe-project.github.io/manual/5.0/sources.html
      SOURCE_STATIC: HttpSource
      # picture_filesにアップロードされた画像が対象
      HTTPSOURCE_BASICLOOKUPSTRATEGY_URL_PREFIX: http://web:3000/picture_files/
      # picture_filesの画像は".download"をつけてアクセスするようになっている
      HTTPSOURCE_BASICLOOKUPSTRATEGY_URL_SUFFIX: '.download'
      # ヘルスチェックを有効化
      ENDPOINT_API_ENABLED: 'true'
    ```
- IIIFのマニフェストファイルは `/iiif/3/{picture_file_id}//info.json` でアクセスする
- IIIFの画像は `/iiif/3/{picture_file_id}/{region}/{size}/{rotation}/{quality}.{format}` でアクセスする
    - 例: http://localhost:8182/iiif/3/1/full/max/0/default.jpg