### PR TITLE
config.hostsの設定を修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,5 @@ module EnjuLeaf
       protocol: base_url.scheme,
       port: base_url.port
     }
-    config.hosts += ['web', '127.0.0.1']
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -75,4 +75,6 @@ Rails.application.configure do
   # config.action_cable.disable_request_forgery_protection = true
 
   config.active_job.queue_adapter     = :resque
+
+  config.hosts += ['web', '127.0.0.1']
 end


### PR DESCRIPTION
Rails 6.1で導入されたDNSリバインディング攻撃の対策を、明示的にdevelopment環境でのみ有効化するように変更するPRです。
https://railsguides.jp/configuring.html#actiondispatch-hostauthorization

既定ではdevelopment環境でのみ有効なのですが、 https://github.com/next-l/enju_leaf/pull/1721 でCataloupeからEnju本体にアクセスさせるために設定を変更したところ、development環境以外でもこの設定が有効になってしまい、アプリケーションにアクセスできなくなってしまいました。