### PR TITLE
環境変数 CANTALOUPE_BASE_URI を追加

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -19,6 +19,8 @@ ENJU_LEAF_STORAGE_ENDPOINT=http://minio:9000
 ENJU_LEAF_ACTION_MAILER_DELIVERY_METHOD=test
 # ENJU_LEAF_RESOURCESYNC_BASE_URL=http://localhost:8080
 
+CANTALOUPE_BASE_URI=http://localhost:8182
+
 no_proxy=localhost,webpacker,minio,solr
 NO_PROXY=${no_proxy}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,6 +139,7 @@ services:
       HTTPSOURCE_BASICLOOKUPSTRATEGY_URL_PREFIX: http://web:3000/picture_files/
       HTTPSOURCE_BASICLOOKUPSTRATEGY_URL_SUFFIX: '.download'
       ENDPOINT_API_ENABLED: 'true'
+      BASE_URI: ${CANTALOUPE_BASE_URI}
     networks:
       internal:
     depends_on:


### PR DESCRIPTION
CantaloupeにアクセスするときのURLを指定します。実際にはCantaloupeの`base_uri`に指定する値になり、これがマニフェストファイルでも使用されます。
https://github.com/cantaloupe-project/cantaloupe/blob/develop/cantaloupe.properties.sample#L40