### PR TITLE
新規ブックマーク作成時のエラーメッセージの設定を修正

### DIFF
--- a/app/views/bookmarks/new.html.erb
+++ b/app/views/bookmarks/new.html.erb
@@ -3,7 +3,7 @@
   <div id="content_list">
 
   <%= form_for(@bookmark) do |f| -%>
-    <%= error_messages(@bookmar) -%>
+    <%= error_messages(@bookmark) -%>
 
     <div class="field">
       <%= f.label t('page.title') -%><br />

--- a/spec/system/bookmarks_spec.rb
+++ b/spec/system/bookmarks_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe 'Bookmarks', type: :system do
+  include Devise::Test::IntegrationHelpers
+  fixtures :all
+
+  describe 'When logged in as Librarian' do
+    it 'should get new bookmark' do
+      sign_in users(:librarian1)
+      visit new_bookmark_path('bookmark[title]': 'ブックマークのテスト')
+
+      expect(page).to have_field('bookmark_title', with: 'ブックマークのテスト')
+    end
+  end
+end


### PR DESCRIPTION
#1726 の修正です。エラーメッセージの表示に使用する変数名が誤っていました。