### PR TITLE
トップページの資料表示でサムネイルのColorboxの表示が無効になっていたのを修正

### DIFF
--- a/app/views/manifestations/_book_jacket.html.erb
+++ b/app/views/manifestations/_book_jacket.html.erb
@@ -1,3 +1,5 @@
+<%= render 'manifestations/colorbox' %>
+
 <div id="manifestation_book_jacket">
   <%- if manifestation and defined?(EnjuManifestationViewer) -%>
     <%= book_jacket(manifestation) -%>

--- a/app/views/manifestations/_book_jacket.html.erb
+++ b/app/views/manifestations/_book_jacket.html.erb
@@ -1,7 +1,7 @@
-<%= render 'manifestations/colorbox' %>
+<% if manifestation %>
+  <%= render 'manifestations/colorbox', manifestation: manifestation %>
 
-<div id="manifestation_book_jacket">
-  <%- if manifestation and defined?(EnjuManifestationViewer) -%>
+  <div id="manifestation_book_jacket">
     <%= book_jacket(manifestation) -%>
-  <%- end -%>
-</div>
+  </div>
+<% end %>

--- a/app/views/manifestations/_colorbox.html.erb
+++ b/app/views/manifestations/_colorbox.html.erb
@@ -1,5 +1,5 @@
 <script>
   $(document).ready(function(){
-    $('a[rel="manifestation_<%= @manifestation.id -%>"]').colorbox({transition:"none", photo:true});
+    $('a[rel="manifestation_<%= manifestation.id -%>"]').colorbox({transition:"none", photo:true});
   })
 </script>

--- a/app/views/manifestations/_pickup.html.erb
+++ b/app/views/manifestations/_pickup.html.erb
@@ -1,7 +1,7 @@
 <% if manifestation %>
   <% cache([manifestation, fragment: 'pickup_html', role: current_user_role_name, locale: @locale]) do %>
     <div id="pickup_book_jacket">
-      <%= book_jacket(manifestation) -%>
+      <%= render 'manifestations/book_jacket', manifestation: manifestation -%>
     </div>
     <div style="float: left">
       <% if defined?(EnjuSubject) %>

--- a/app/views/manifestations/show.html.erb
+++ b/app/views/manifestations/show.html.erb
@@ -24,7 +24,6 @@
       <li><%= link_to t('page.new', model: t('activerecord.models.picture_file')), new_picture_file_path(manifestation_id: @manifestation.id) -%></li>
     <%- end -%>
   </ul>
-  <%= render 'manifestations/colorbox' %>
   <%- if user_signed_in? -%>
     <div id="call_number_content">
       <%- @manifestation.items.on_shelf.each do |item| -%>


### PR DESCRIPTION
資料のサムネイルの表示にはColorboxを使用していますが、これが資料詳細ページでは有効になっているものの、トップページで有効になっていませんでした。
https://www.jacklmoore.com/colorbox/