### PR TITLE
created_atとupdated_atカラムにnot null制約を追加

### DIFF
--- a/app/models/accept.rb
+++ b/app/models/accept.rb
@@ -20,6 +20,6 @@ end
 #  basket_id    :integer
 #  item_id      :integer
 #  librarian_id :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -299,8 +299,8 @@ end
 #  full_name                           :string
 #  full_name_transcription             :text
 #  full_name_alternative               :text
-#  created_at                          :datetime
-#  updated_at                          :datetime
+#  created_at                          :datetime         not null
+#  updated_at                          :datetime         not null
 #  zip_code_1                          :string
 #  zip_code_2                          :string
 #  address_1                           :text

--- a/app/models/agent_import_file.rb
+++ b/app/models/agent_import_file.rb
@@ -247,8 +247,8 @@ end
 #  agent_import_content_type :string
 #  agent_import_file_size    :integer
 #  agent_import_updated_at   :datetime
-#  created_at                :datetime
-#  updated_at                :datetime
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
 #  agent_import_fingerprint  :string
 #  error_message             :text
 #  edit_mode                 :string

--- a/app/models/agent_import_file_transition.rb
+++ b/app/models/agent_import_file_transition.rb
@@ -14,7 +14,7 @@ end
 #  metadata             :text             default({})
 #  sort_key             :integer
 #  agent_import_file_id :integer
-#  created_at           :datetime
-#  updated_at           :datetime
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
 #  most_recent          :boolean          not null
 #

--- a/app/models/agent_import_result.rb
+++ b/app/models/agent_import_result.rb
@@ -15,6 +15,6 @@ end
 #  agent_import_file_id :integer
 #  agent_id             :integer
 #  body                 :text
-#  created_at           :datetime
-#  updated_at           :datetime
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
 #

--- a/app/models/agent_merge.rb
+++ b/app/models/agent_merge.rb
@@ -12,6 +12,6 @@ end
 #  id                  :integer          not null, primary key
 #  agent_id            :integer          not null
 #  agent_merge_list_id :integer          not null
-#  created_at          :datetime
-#  updated_at          :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #

--- a/app/models/agent_merge_list.rb
+++ b/app/models/agent_merge_list.rb
@@ -22,6 +22,6 @@ end
 #
 #  id         :integer          not null, primary key
 #  title      :string
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/app/models/agent_relationship.rb
+++ b/app/models/agent_relationship.rb
@@ -18,7 +18,7 @@ end
 #  parent_id                  :integer
 #  child_id                   :integer
 #  agent_relationship_type_id :integer
-#  created_at                 :datetime
-#  updated_at                 :datetime
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
 #  position                   :integer
 #

--- a/app/models/agent_relationship_type.rb
+++ b/app/models/agent_relationship_type.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/agent_type.rb
+++ b/app/models/agent_type.rb
@@ -12,6 +12,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/basket.rb
+++ b/app/models/basket.rb
@@ -34,6 +34,6 @@ end
 #  user_id      :integer
 #  note         :text
 #  lock_version :integer          default(0), not null
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -192,6 +192,6 @@ end
 #  url              :string
 #  note             :text
 #  shared           :boolean
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/app/models/bookmark_stat.rb
+++ b/app/models/bookmark_stat.rb
@@ -57,6 +57,6 @@ end
 #  started_at   :datetime
 #  completed_at :datetime
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/bookmark_stat_has_manifestation.rb
+++ b/app/models/bookmark_stat_has_manifestation.rb
@@ -15,6 +15,6 @@ end
 #  bookmark_stat_id :integer          not null
 #  manifestation_id :integer          not null
 #  bookmarks_count  :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/app/models/bookmark_stat_transition.rb
+++ b/app/models/bookmark_stat_transition.rb
@@ -14,7 +14,7 @@ end
 #  metadata         :text             default({})
 #  sort_key         :integer
 #  bookmark_stat_id :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #  most_recent      :boolean          not null
 #

--- a/app/models/bookstore.rb
+++ b/app/models/bookstore.rb
@@ -26,6 +26,6 @@ end
 #  fax_number       :string
 #  url              :string
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/app/models/budget_type.rb
+++ b/app/models/budget_type.rb
@@ -19,6 +19,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/carrier_type.rb
+++ b/app/models/carrier_type.rb
@@ -46,8 +46,8 @@ end
 #  display_name            :text
 #  note                    :text
 #  position                :integer
-#  created_at              :datetime
-#  updated_at              :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #  attachment_file_name    :string
 #  attachment_content_type :string
 #  attachment_file_size    :bigint

--- a/app/models/carrier_type_has_checkout_type.rb
+++ b/app/models/carrier_type_has_checkout_type.rb
@@ -19,6 +19,6 @@ end
 #  checkout_type_id :integer          not null
 #  note             :text
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/app/models/checked_item.rb
+++ b/app/models/checked_item.rb
@@ -127,7 +127,7 @@ end
 #  basket_id    :integer          not null
 #  librarian_id :integer
 #  due_date     :datetime         not null
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  user_id      :integer
 #

--- a/app/models/checkin.rb
+++ b/app/models/checkin.rb
@@ -85,7 +85,7 @@ end
 #  item_id      :integer          not null
 #  librarian_id :integer
 #  basket_id    :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  lock_version :integer          default(0), not null
 #

--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -199,8 +199,8 @@ end
 #  due_date               :datetime
 #  checkout_renewal_count :integer          default(0), not null
 #  lock_version           :integer          default(0), not null
-#  created_at             :datetime
-#  updated_at             :datetime
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
 #  shelf_id               :integer
 #  library_id             :integer
 #

--- a/app/models/checkout_stat_has_manifestation.rb
+++ b/app/models/checkout_stat_has_manifestation.rb
@@ -15,6 +15,6 @@ end
 #  manifestation_checkout_stat_id :integer          not null
 #  manifestation_id               :integer          not null
 #  checkouts_count                :integer
-#  created_at                     :datetime
-#  updated_at                     :datetime
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
 #

--- a/app/models/checkout_stat_has_user.rb
+++ b/app/models/checkout_stat_has_user.rb
@@ -15,6 +15,6 @@ end
 #  user_checkout_stat_id :integer          not null
 #  user_id               :integer          not null
 #  checkouts_count       :integer          default(0), not null
-#  created_at            :datetime
-#  updated_at            :datetime
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
 #

--- a/app/models/checkout_type.rb
+++ b/app/models/checkout_type.rb
@@ -23,6 +23,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/circulation_status.rb
+++ b/app/models/circulation_status.rb
@@ -22,6 +22,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -21,8 +21,8 @@ end
 #  category               :string           not null
 #  note                   :text
 #  classification_type_id :integer          not null
-#  created_at             :datetime
-#  updated_at             :datetime
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
 #  lft                    :integer
 #  rgt                    :integer
 #  manifestation_id       :integer

--- a/app/models/classification_type.rb
+++ b/app/models/classification_type.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/color.rb
+++ b/app/models/color.rb
@@ -15,6 +15,6 @@ end
 #  property         :string
 #  code             :string
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/app/models/content_type.rb
+++ b/app/models/content_type.rb
@@ -12,6 +12,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/create.rb
+++ b/app/models/create.rb
@@ -23,7 +23,7 @@ end
 #  agent_id       :integer          not null
 #  work_id        :integer          not null
 #  position       :integer
-#  created_at     :datetime
-#  updated_at     :datetime
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
 #  create_type_id :integer
 #

--- a/app/models/create_type.rb
+++ b/app/models/create_type.rb
@@ -12,6 +12,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/donate.rb
+++ b/app/models/donate.rb
@@ -10,6 +10,6 @@ end
 #  id         :integer          not null, primary key
 #  agent_id   :integer          not null
 #  item_id    :integer          not null
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -117,7 +117,7 @@ end
 #  end_at            :datetime
 #  all_day           :boolean          default(FALSE), not null
 #  display_name      :text
-#  created_at        :datetime
-#  updated_at        :datetime
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #  place_id          :integer
 #

--- a/app/models/event_category.rb
+++ b/app/models/event_category.rb
@@ -17,6 +17,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/event_export_file.rb
+++ b/app/models/event_export_file.rb
@@ -61,6 +61,6 @@ end
 #  event_export_file_size    :bigint
 #  event_export_updated_at   :datetime
 #  executed_at               :datetime
-#  created_at                :datetime
-#  updated_at                :datetime
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
 #

--- a/app/models/event_export_file_transition.rb
+++ b/app/models/event_export_file_transition.rb
@@ -14,7 +14,7 @@ end
 #  metadata             :text             default({})
 #  sort_key             :integer
 #  event_export_file_id :integer
-#  created_at           :datetime
-#  updated_at           :datetime
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
 #  most_recent          :boolean          not null
 #

--- a/app/models/event_import_file.rb
+++ b/app/models/event_import_file.rb
@@ -218,8 +218,8 @@ end
 #  event_import_file_size    :integer
 #  event_import_updated_at   :datetime
 #  edit_mode                 :string
-#  created_at                :datetime
-#  updated_at                :datetime
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
 #  event_import_fingerprint  :string
 #  error_message             :text
 #  user_encoding             :string

--- a/app/models/event_import_file_transition.rb
+++ b/app/models/event_import_file_transition.rb
@@ -14,7 +14,7 @@ end
 #  metadata             :text             default({})
 #  sort_key             :integer
 #  event_import_file_id :integer
-#  created_at           :datetime
-#  updated_at           :datetime
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
 #  most_recent          :boolean          not null
 #

--- a/app/models/event_import_result.rb
+++ b/app/models/event_import_result.rb
@@ -20,6 +20,6 @@ end
 #  event_import_file_id :integer
 #  event_id             :integer
 #  body                 :text
-#  created_at           :datetime
-#  updated_at           :datetime
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
 #

--- a/app/models/form_of_work.rb
+++ b/app/models/form_of_work.rb
@@ -12,6 +12,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/frequency.rb
+++ b/app/models/frequency.rb
@@ -12,6 +12,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/identifier.rb
+++ b/app/models/identifier.rb
@@ -82,6 +82,6 @@ end
 #  manifestation_id   :integer
 #  primary            :boolean
 #  position           :integer
-#  created_at         :datetime
-#  updated_at         :datetime
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #

--- a/app/models/identifier_type.rb
+++ b/app/models/identifier_type.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/import_request.rb
+++ b/app/models/import_request.rb
@@ -74,6 +74,6 @@ end
 #  isbn             :string
 #  manifestation_id :integer
 #  user_id          :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/app/models/import_request_transition.rb
+++ b/app/models/import_request_transition.rb
@@ -14,7 +14,7 @@ end
 #  metadata          :text             default({})
 #  sort_key          :integer
 #  import_request_id :integer
-#  created_at        :datetime
-#  updated_at        :datetime
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #  most_recent       :boolean          not null
 #

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -42,8 +42,8 @@ end
 #  item_id            :integer
 #  inventory_file_id  :integer
 #  note               :text
-#  created_at         :datetime
-#  updated_at         :datetime
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #  item_identifier    :string
 #  current_shelf_name :string
 #

--- a/app/models/inventory_file.rb
+++ b/app/models/inventory_file.rb
@@ -75,8 +75,8 @@ end
 #  size                   :integer
 #  user_id                :integer
 #  note                   :text
-#  created_at             :datetime
-#  updated_at             :datetime
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
 #  inventory_file_name    :string
 #  inventory_content_type :string
 #  inventory_file_size    :integer

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -155,8 +155,8 @@ end
 #  id                      :integer          not null, primary key
 #  call_number             :string
 #  item_identifier         :string
-#  created_at              :datetime
-#  updated_at              :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #  shelf_id                :integer          default(1), not null
 #  include_supplements     :boolean          default(FALSE), not null
 #  note                    :text

--- a/app/models/item_has_use_restriction.rb
+++ b/app/models/item_has_use_restriction.rb
@@ -15,6 +15,6 @@ end
 #  id                 :integer          not null, primary key
 #  item_id            :integer          not null
 #  use_restriction_id :integer          not null
-#  created_at         :datetime
-#  updated_at         :datetime
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -100,8 +100,8 @@ end
 #  users_count           :integer          default(0), not null
 #  position              :integer
 #  country_id            :integer
-#  created_at            :datetime
-#  updated_at            :datetime
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
 #  opening_hour          :text
 #  isil                  :string
 #  latitude              :float

--- a/app/models/library_group.rb
+++ b/app/models/library_group.rb
@@ -92,8 +92,8 @@ end
 #  note                          :text
 #  country_id                    :integer
 #  position                      :integer
-#  created_at                    :datetime
-#  updated_at                    :datetime
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
 #  admin_networks                :text
 #  allow_bookmark_external_url   :boolean          default(FALSE), not null
 #  url                           :string           default("http://localhost:3000/")

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -11,6 +11,6 @@ end
 #  display_name :string
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -721,8 +721,8 @@ end
 #  manifestation_identifier        :string
 #  date_of_publication             :datetime
 #  date_copyrighted                :datetime
-#  created_at                      :datetime
-#  updated_at                      :datetime
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
 #  access_address                  :string
 #  language_id                     :integer          default(1), not null
 #  carrier_type_id                 :integer          default(1), not null

--- a/app/models/manifestation_checkout_stat.rb
+++ b/app/models/manifestation_checkout_stat.rb
@@ -52,8 +52,8 @@ end
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  started_at   :datetime
 #  completed_at :datetime
 #  user_id      :integer

--- a/app/models/manifestation_checkout_stat_transition.rb
+++ b/app/models/manifestation_checkout_stat_transition.rb
@@ -14,7 +14,7 @@ end
 #  metadata                       :text             default({})
 #  sort_key                       :integer
 #  manifestation_checkout_stat_id :integer
-#  created_at                     :datetime
-#  updated_at                     :datetime
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
 #  most_recent                    :boolean          not null
 #

--- a/app/models/manifestation_relationship.rb
+++ b/app/models/manifestation_relationship.rb
@@ -21,7 +21,7 @@ end
 #  parent_id                          :integer
 #  child_id                           :integer
 #  manifestation_relationship_type_id :integer
-#  created_at                         :datetime
-#  updated_at                         :datetime
+#  created_at                         :datetime         not null
+#  updated_at                         :datetime         not null
 #  position                           :integer
 #

--- a/app/models/manifestation_relationship_type.rb
+++ b/app/models/manifestation_relationship_type.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/manifestation_reserve_stat.rb
+++ b/app/models/manifestation_reserve_stat.rb
@@ -52,8 +52,8 @@ end
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  started_at   :datetime
 #  completed_at :datetime
 #  user_id      :integer

--- a/app/models/manifestation_reserve_stat_transition.rb
+++ b/app/models/manifestation_reserve_stat_transition.rb
@@ -14,7 +14,7 @@ end
 #  metadata                      :text             default({})
 #  sort_key                      :integer
 #  manifestation_reserve_stat_id :integer
-#  created_at                    :datetime
-#  updated_at                    :datetime
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
 #  most_recent                   :boolean          not null
 #

--- a/app/models/medium_of_performance.rb
+++ b/app/models/medium_of_performance.rb
@@ -12,6 +12,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/news_feed.rb
+++ b/app/models/news_feed.rb
@@ -62,6 +62,6 @@ end
 #  url              :string
 #  body             :text
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/app/models/news_post.rb
+++ b/app/models/news_post.rb
@@ -44,7 +44,7 @@ end
 #  note             :text
 #  position         :integer
 #  draft            :boolean          default(FALSE), not null
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #  url              :string
 #

--- a/app/models/nii_type.rb
+++ b/app/models/nii_type.rb
@@ -12,6 +12,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/oai_provider.rb
+++ b/app/models/oai_provider.rb
@@ -1,9 +1,11 @@
 class OaiProvider < OAI::Provider::Base
   library_group = LibraryGroup.site_config
-  repository_name library_group.display_name
+  if library_group
+    repository_name library_group.display_name
+    admin_email library_group.email
+  end
   repository_url EnjuOai::OaiModel.repository_url
   record_prefix EnjuOai::OaiModel.record_prefix
-  admin_email library_group.email
   source_model OAI::Provider::ActiveRecordWrapper.new(
     Manifestation.where(required_role: 1)
   )

--- a/app/models/own.rb
+++ b/app/models/own.rb
@@ -24,6 +24,6 @@ end
 #  agent_id   :integer          not null
 #  item_id    :integer          not null
 #  position   :integer
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/app/models/participate.rb
+++ b/app/models/participate.rb
@@ -16,6 +16,6 @@ end
 #  agent_id   :integer          not null
 #  event_id   :integer          not null
 #  position   :integer
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/app/models/picture_file.rb
+++ b/app/models/picture_file.rb
@@ -48,8 +48,8 @@ end
 #  picture_attachable_type :string
 #  title                   :text
 #  position                :integer
-#  created_at              :datetime
-#  updated_at              :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #  picture_file_name       :string
 #  picture_content_type    :string
 #  picture_file_size       :integer

--- a/app/models/produce.rb
+++ b/app/models/produce.rb
@@ -24,7 +24,7 @@ end
 #  agent_id         :integer          not null
 #  manifestation_id :integer          not null
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #  produce_type_id  :integer
 #

--- a/app/models/produce_type.rb
+++ b/app/models/produce_type.rb
@@ -12,6 +12,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -87,8 +87,8 @@ end
 #  note                     :text
 #  keyword_list             :text
 #  required_role_id         :integer
-#  created_at               :datetime
-#  updated_at               :datetime
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
 #  checkout_icalendar_token :string
 #  save_checkout_history    :boolean          default(FALSE), not null
 #  expired_at               :datetime

--- a/app/models/realize.rb
+++ b/app/models/realize.rb
@@ -23,7 +23,7 @@ end
 #  agent_id        :integer          not null
 #  expression_id   :integer          not null
 #  position        :integer
-#  created_at      :datetime
-#  updated_at      :datetime
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
 #  realize_type_id :integer
 #

--- a/app/models/realize_type.rb
+++ b/app/models/realize_type.rb
@@ -12,6 +12,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/request_status_type.rb
+++ b/app/models/request_status_type.rb
@@ -19,6 +19,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/request_type.rb
+++ b/app/models/request_type.rb
@@ -18,6 +18,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/reserve.rb
+++ b/app/models/reserve.rb
@@ -326,8 +326,8 @@ end
 #  item_id                      :integer
 #  request_status_type_id       :integer          not null
 #  checked_out_at               :datetime
-#  created_at                   :datetime
-#  updated_at                   :datetime
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
 #  canceled_at                  :datetime
 #  expired_at                   :datetime
 #  expiration_notice_to_patron  :boolean          default(FALSE)

--- a/app/models/reserve_stat_has_manifestation.rb
+++ b/app/models/reserve_stat_has_manifestation.rb
@@ -15,6 +15,6 @@ end
 #  manifestation_reserve_stat_id :integer          not null
 #  manifestation_id              :integer          not null
 #  reserves_count                :integer
-#  created_at                    :datetime
-#  updated_at                    :datetime
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
 #

--- a/app/models/reserve_stat_has_user.rb
+++ b/app/models/reserve_stat_has_user.rb
@@ -15,6 +15,6 @@ end
 #  user_reserve_stat_id :integer          not null
 #  user_id              :integer          not null
 #  reserves_count       :integer
-#  created_at           :datetime
-#  updated_at           :datetime
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
 #

--- a/app/models/reserve_transition.rb
+++ b/app/models/reserve_transition.rb
@@ -14,7 +14,7 @@ end
 #  metadata    :text             default({})
 #  sort_key    :integer
 #  reserve_id  :integer
-#  created_at  :datetime
-#  updated_at  :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
 #  most_recent :boolean          not null
 #

--- a/app/models/resource_export_file.rb
+++ b/app/models/resource_export_file.rb
@@ -61,6 +61,6 @@ end
 #  resource_export_file_size    :bigint
 #  resource_export_updated_at   :datetime
 #  executed_at                  :datetime
-#  created_at                   :datetime
-#  updated_at                   :datetime
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
 #

--- a/app/models/resource_export_file_transition.rb
+++ b/app/models/resource_export_file_transition.rb
@@ -14,7 +14,7 @@ end
 #  metadata                :text             default({})
 #  sort_key                :integer
 #  resource_export_file_id :integer
-#  created_at              :datetime
-#  updated_at              :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #  most_recent             :boolean          not null
 #

--- a/app/models/resource_import_file.rb
+++ b/app/models/resource_import_file.rb
@@ -900,8 +900,8 @@ end
 #  resource_import_content_type :string
 #  resource_import_file_size    :integer
 #  resource_import_updated_at   :datetime
-#  created_at                   :datetime
-#  updated_at                   :datetime
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
 #  edit_mode                    :string
 #  resource_import_fingerprint  :string
 #  error_message                :text

--- a/app/models/resource_import_file_transition.rb
+++ b/app/models/resource_import_file_transition.rb
@@ -14,7 +14,7 @@ end
 #  metadata                :text             default({})
 #  sort_key                :integer
 #  resource_import_file_id :integer
-#  created_at              :datetime
-#  updated_at              :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #  most_recent             :boolean          not null
 #

--- a/app/models/resource_import_result.rb
+++ b/app/models/resource_import_result.rb
@@ -18,7 +18,7 @@ end
 #  manifestation_id        :integer
 #  item_id                 :integer
 #  body                    :text
-#  created_at              :datetime
-#  updated_at              :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #  error_message           :text
 #

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -30,8 +30,8 @@ end
 #  name         :string           not null
 #  display_name :string
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  score        :integer          default(0), not null
 #  position     :integer
 #

--- a/app/models/search_engine.rb
+++ b/app/models/search_engine.rb
@@ -35,6 +35,6 @@ end
 #  additional_param :text
 #  note             :text
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/app/models/series_statement.rb
+++ b/app/models/series_statement.rb
@@ -57,8 +57,8 @@ end
 #  title_subseries                    :text
 #  numbering_subseries                :text
 #  position                           :integer
-#  created_at                         :datetime
-#  updated_at                         :datetime
+#  created_at                         :datetime         not null
+#  updated_at                         :datetime         not null
 #  title_transcription                :text
 #  title_alternative                  :text
 #  series_statement_identifier        :string

--- a/app/models/series_statement_merge.rb
+++ b/app/models/series_statement_merge.rb
@@ -12,6 +12,6 @@ end
 #  id                             :integer          not null, primary key
 #  series_statement_id            :integer          not null
 #  series_statement_merge_list_id :integer          not null
-#  created_at                     :datetime
-#  updated_at                     :datetime
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
 #

--- a/app/models/series_statement_merge_list.rb
+++ b/app/models/series_statement_merge_list.rb
@@ -12,6 +12,6 @@ end
 #
 #  id         :integer          not null, primary key
 #  title      :string
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/app/models/shelf.rb
+++ b/app/models/shelf.rb
@@ -59,7 +59,7 @@ end
 #  library_id   :integer          not null
 #  items_count  :integer          default(0), not null
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  closed       :boolean          default(FALSE), not null
 #

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -31,8 +31,8 @@ end
 #  note                    :text
 #  required_role_id        :integer          default(1), not null
 #  lock_version            :integer          default(0), not null
-#  created_at              :datetime
-#  updated_at              :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #  url                     :string
 #  manifestation_id        :integer
 #  subject_heading_type_id :integer

--- a/app/models/subject_heading_type.rb
+++ b/app/models/subject_heading_type.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/subject_type.rb
+++ b/app/models/subject_type.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/subscribe.rb
+++ b/app/models/subscribe.rb
@@ -15,6 +15,6 @@ end
 #  work_id         :integer          not null
 #  start_at        :datetime         not null
 #  end_at          :datetime         not null
-#  created_at      :datetime
-#  updated_at      :datetime
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
 #

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -32,6 +32,6 @@ end
 #  user_id          :integer
 #  order_list_id    :integer
 #  subscribes_count :integer          default(0), not null
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -50,6 +50,6 @@ end
 #  id             :integer          not null, primary key
 #  name           :string
 #  taggings_count :integer          default(0)
-#  created_at     :datetime
-#  updated_at     :datetime
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
 #

--- a/app/models/use_restriction.rb
+++ b/app/models/use_restriction.rb
@@ -22,6 +22,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/app/models/user_checkout_stat.rb
+++ b/app/models/user_checkout_stat.rb
@@ -51,8 +51,8 @@ end
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  started_at   :datetime
 #  completed_at :datetime
 #  user_id      :integer

--- a/app/models/user_checkout_stat_transition.rb
+++ b/app/models/user_checkout_stat_transition.rb
@@ -14,7 +14,7 @@ end
 #  metadata              :text             default({})
 #  sort_key              :integer
 #  user_checkout_stat_id :integer
-#  created_at            :datetime
-#  updated_at            :datetime
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
 #  most_recent           :boolean          not null
 #

--- a/app/models/user_export_file.rb
+++ b/app/models/user_export_file.rb
@@ -61,6 +61,6 @@ end
 #  user_export_file_size    :bigint
 #  user_export_updated_at   :datetime
 #  executed_at              :datetime
-#  created_at               :datetime
-#  updated_at               :datetime
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
 #

--- a/app/models/user_export_file_transition.rb
+++ b/app/models/user_export_file_transition.rb
@@ -14,7 +14,7 @@ end
 #  metadata            :text             default({})
 #  sort_key            :integer
 #  user_export_file_id :integer
-#  created_at          :datetime
-#  updated_at          :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #  most_recent         :boolean          not null
 #

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -19,8 +19,8 @@ end
 #  display_name                     :text
 #  note                             :text
 #  position                         :integer
-#  created_at                       :datetime
-#  updated_at                       :datetime
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
 #  valid_period_for_new_user        :integer          default(0), not null
 #  expired_at                       :datetime
 #  number_of_day_to_notify_overdue  :integer          default(0), not null

--- a/app/models/user_group_has_checkout_type.rb
+++ b/app/models/user_group_has_checkout_type.rb
@@ -56,7 +56,7 @@ end
 #  fixed_due_date                  :datetime
 #  note                            :text
 #  position                        :integer
-#  created_at                      :datetime
-#  updated_at                      :datetime
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
 #  current_checkout_count          :integer
 #

--- a/app/models/user_has_role.rb
+++ b/app/models/user_has_role.rb
@@ -11,6 +11,6 @@ end
 #  id         :integer          not null, primary key
 #  user_id    :integer          not null
 #  role_id    :integer          not null
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/app/models/user_import_file.rb
+++ b/app/models/user_import_file.rb
@@ -342,8 +342,8 @@ end
 #  user_import_fingerprint  :string
 #  edit_mode                :string
 #  error_message            :text
-#  created_at               :datetime
-#  updated_at               :datetime
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
 #  user_encoding            :string
 #  default_library_id       :integer
 #  default_user_group_id    :integer

--- a/app/models/user_import_file_transition.rb
+++ b/app/models/user_import_file_transition.rb
@@ -14,7 +14,7 @@ end
 #  metadata            :text             default({})
 #  sort_key            :integer
 #  user_import_file_id :integer
-#  created_at          :datetime
-#  updated_at          :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #  most_recent         :boolean          not null
 #

--- a/app/models/user_import_result.rb
+++ b/app/models/user_import_result.rb
@@ -14,7 +14,7 @@ end
 #  user_import_file_id :integer
 #  user_id             :integer
 #  body                :text
-#  created_at          :datetime
-#  updated_at          :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #  error_message       :text
 #

--- a/app/models/user_reserve_stat.rb
+++ b/app/models/user_reserve_stat.rb
@@ -51,8 +51,8 @@ end
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  started_at   :datetime
 #  completed_at :datetime
 #  user_id      :integer

--- a/app/models/user_reserve_stat_transition.rb
+++ b/app/models/user_reserve_stat_transition.rb
@@ -14,7 +14,7 @@ end
 #  metadata             :text             default({})
 #  sort_key             :integer
 #  user_reserve_stat_id :integer
-#  created_at           :datetime
-#  updated_at           :datetime
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
 #  most_recent          :boolean          not null
 #

--- a/db/migrate/20221112015501_add_not_null_on_timestamps.rb
+++ b/db/migrate/20221112015501_add_not_null_on_timestamps.rb
@@ -1,0 +1,15 @@
+class AddNotNullOnTimestamps < ActiveRecord::Migration[6.1]
+  def change
+    ActiveRecord::Base.connection.tables.each do |table|
+      next if ['schema_migrations', 'countries', 'languages'].include?(table)
+
+      change_column_null table, :created_at, false
+      change_column table, :created_at, :datetime, precision: 6
+
+      next if table == 'taggings'
+
+      change_column_null table, :updated_at, false unless table == 'taggings'
+      change_column table, :updated_at, :datetime, precision: 6
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_07_153151) do
+ActiveRecord::Schema.define(version: 2022_11_12_015501) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,8 +19,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "basket_id"
     t.integer "item_id"
     t.integer "librarian_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["basket_id"], name: "index_accepts_on_basket_id"
     t.index ["item_id"], name: "index_accepts_on_item_id"
     t.index ["librarian_id"], name: "index_accepts_on_librarian_id"
@@ -31,8 +31,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "metadata", default: "{}"
     t.integer "sort_key"
     t.integer "agent_import_file_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.boolean "most_recent", null: false
     t.index ["agent_import_file_id", "most_recent"], name: "index_agent_import_file_transitions_parent_most_recent", unique: true, where: "most_recent"
     t.index ["agent_import_file_id"], name: "index_agent_import_file_transitions_on_agent_import_file_id"
@@ -50,8 +50,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.string "agent_import_content_type"
     t.integer "agent_import_file_size"
     t.datetime "agent_import_updated_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "agent_import_fingerprint"
     t.text "error_message"
     t.string "edit_mode"
@@ -64,21 +64,21 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "agent_import_file_id"
     t.integer "agent_id"
     t.text "body"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "agent_merge_lists", id: :serial, force: :cascade do |t|
     t.string "title"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "agent_merges", id: :serial, force: :cascade do |t|
     t.integer "agent_id", null: false
     t.integer "agent_merge_list_id", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["agent_id"], name: "index_agent_merges_on_agent_id"
     t.index ["agent_merge_list_id"], name: "index_agent_merges_on_agent_merge_list_id"
   end
@@ -88,16 +88,16 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "agent_relationships", id: :serial, force: :cascade do |t|
     t.integer "parent_id"
     t.integer "child_id"
     t.integer "agent_relationship_type_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "position"
     t.index ["child_id"], name: "index_agent_relationships_on_child_id"
     t.index ["parent_id"], name: "index_agent_relationships_on_parent_id"
@@ -108,8 +108,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "agents", id: :serial, force: :cascade do |t|
@@ -124,8 +124,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.string "full_name"
     t.text "full_name_transcription"
     t.text "full_name_alternative"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "zip_code_1"
     t.string "zip_code_2"
     t.text "address_1"
@@ -170,8 +170,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "user_id"
     t.text "note"
     t.integer "lock_version", default: 0, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_baskets_on_user_id"
   end
 
@@ -179,8 +179,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "bookmark_stat_id", null: false
     t.integer "manifestation_id", null: false
     t.integer "bookmarks_count"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["bookmark_stat_id"], name: "index_bookmark_stat_has_manifestations_on_bookmark_stat_id"
     t.index ["manifestation_id"], name: "index_bookmark_stat_has_manifestations_on_manifestation_id"
   end
@@ -190,8 +190,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "metadata", default: "{}"
     t.integer "sort_key"
     t.integer "bookmark_stat_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.boolean "most_recent", null: false
     t.index ["bookmark_stat_id", "most_recent"], name: "index_bookmark_stat_transitions_parent_most_recent", unique: true, where: "most_recent"
     t.index ["bookmark_stat_id"], name: "index_bookmark_stat_transitions_on_bookmark_stat_id"
@@ -204,8 +204,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.datetime "started_at"
     t.datetime "completed_at"
     t.text "note"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "bookmarks", id: :serial, force: :cascade do |t|
@@ -215,8 +215,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.string "url"
     t.text "note"
     t.boolean "shared"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["manifestation_id"], name: "index_bookmarks_on_manifestation_id"
     t.index ["url"], name: "index_bookmarks_on_url"
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
@@ -231,8 +231,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.string "fax_number"
     t.string "url"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "budget_types", id: :serial, force: :cascade do |t|
@@ -240,8 +240,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "carrier_type_has_checkout_types", id: :serial, force: :cascade do |t|
@@ -249,8 +249,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "checkout_type_id", null: false
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["carrier_type_id"], name: "index_carrier_type_has_checkout_types_on_m_form_id"
     t.index ["checkout_type_id"], name: "index_carrier_type_has_checkout_types_on_checkout_type_id"
   end
@@ -260,8 +260,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
     t.bigint "attachment_file_size"
@@ -273,8 +273,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "basket_id", null: false
     t.integer "librarian_id"
     t.datetime "due_date", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "user_id"
     t.index ["basket_id"], name: "index_checked_items_on_basket_id"
     t.index ["item_id"], name: "index_checked_items_on_item_id"
@@ -286,8 +286,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "item_id", null: false
     t.integer "librarian_id"
     t.integer "basket_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "lock_version", default: 0, null: false
     t.index ["basket_id"], name: "index_checkins_on_basket_id"
     t.index ["item_id"], name: "index_checkins_on_item_id"
@@ -298,8 +298,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "manifestation_checkout_stat_id", null: false
     t.integer "manifestation_id", null: false
     t.integer "checkouts_count"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["manifestation_checkout_stat_id"], name: "index_checkout_stat_has_manifestations_on_checkout_stat_id"
     t.index ["manifestation_id"], name: "index_checkout_stat_has_manifestations_on_manifestation_id"
   end
@@ -308,8 +308,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "user_checkout_stat_id", null: false
     t.integer "user_id", null: false
     t.integer "checkouts_count", default: 0, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["user_checkout_stat_id"], name: "index_checkout_stat_has_users_on_user_checkout_stat_id"
     t.index ["user_id"], name: "index_checkout_stat_has_users_on_user_id"
   end
@@ -319,8 +319,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_checkout_types_on_name"
   end
 
@@ -333,8 +333,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.datetime "due_date"
     t.integer "checkout_renewal_count", default: 0, null: false
     t.integer "lock_version", default: 0, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "shelf_id"
     t.integer "library_id"
     t.index ["basket_id"], name: "index_checkouts_on_basket_id"
@@ -352,8 +352,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "classification_types", id: :serial, force: :cascade do |t|
@@ -361,8 +361,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "classifications", id: :serial, force: :cascade do |t|
@@ -370,8 +370,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.string "category", null: false
     t.text "note"
     t.integer "classification_type_id", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "lft"
     t.integer "rgt"
     t.integer "manifestation_id"
@@ -388,8 +388,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.string "property"
     t.string "code"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["library_group_id"], name: "index_colors_on_library_group_id"
   end
 
@@ -398,8 +398,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "countries", id: :serial, force: :cascade do |t|
@@ -421,16 +421,16 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "creates", id: :serial, force: :cascade do |t|
     t.integer "agent_id", null: false
     t.integer "work_id", null: false
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "create_type_id"
     t.index ["agent_id"], name: "index_creates_on_agent_id"
     t.index ["work_id"], name: "index_creates_on_work_id"
@@ -440,8 +440,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "user_id"
     t.integer "item_id"
     t.integer "message_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["item_id"], name: "index_demands_on_item_id"
     t.index ["message_id"], name: "index_demands_on_message_id"
     t.index ["user_id"], name: "index_demands_on_user_id"
@@ -450,8 +450,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
   create_table "donates", id: :serial, force: :cascade do |t|
     t.integer "agent_id", null: false
     t.integer "item_id", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["agent_id"], name: "index_donates_on_agent_id"
     t.index ["item_id"], name: "index_donates_on_item_id"
   end
@@ -461,8 +461,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "event_export_file_transitions", id: :serial, force: :cascade do |t|
@@ -470,8 +470,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "metadata", default: "{}"
     t.integer "sort_key"
     t.integer "event_export_file_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.boolean "most_recent", null: false
     t.index ["event_export_file_id", "most_recent"], name: "index_event_export_file_transitions_parent_most_recent", unique: true, where: "most_recent"
     t.index ["event_export_file_id"], name: "index_event_export_file_transitions_on_file_id"
@@ -485,8 +485,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.bigint "event_export_file_size"
     t.datetime "event_export_updated_at"
     t.datetime "executed_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_event_export_files_on_user_id"
   end
 
@@ -495,8 +495,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "metadata", default: "{}"
     t.integer "sort_key"
     t.integer "event_import_file_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.boolean "most_recent", null: false
     t.index ["event_import_file_id", "most_recent"], name: "index_event_import_file_transitions_parent_most_recent", unique: true, where: "most_recent"
     t.index ["event_import_file_id"], name: "index_event_import_file_transitions_on_event_import_file_id"
@@ -515,8 +515,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "event_import_file_size"
     t.datetime "event_import_updated_at"
     t.string "edit_mode"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "event_import_fingerprint"
     t.text "error_message"
     t.string "user_encoding"
@@ -530,8 +530,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "event_import_file_id"
     t.integer "event_id"
     t.text "body"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "events", id: :serial, force: :cascade do |t|
@@ -543,8 +543,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.datetime "end_at"
     t.boolean "all_day", default: false, null: false
     t.text "display_name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "place_id"
     t.index ["event_category_id"], name: "index_events_on_event_category_id"
     t.index ["library_id"], name: "index_events_on_library_id"
@@ -556,8 +556,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "frequencies", id: :serial, force: :cascade do |t|
@@ -565,8 +565,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "identifier_types", id: :serial, force: :cascade do |t|
@@ -574,8 +574,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "identifiers", id: :serial, force: :cascade do |t|
@@ -584,8 +584,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "manifestation_id"
     t.boolean "primary"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["body", "identifier_type_id"], name: "index_identifiers_on_body_and_identifier_type_id"
     t.index ["manifestation_id"], name: "index_identifiers_on_manifestation_id"
   end
@@ -595,8 +595,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.string "email"
     t.string "password_digest"
     t.integer "profile_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "provider"
     t.index ["email"], name: "index_identities_on_email"
     t.index ["name"], name: "index_identities_on_name"
@@ -608,8 +608,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "metadata", default: "{}"
     t.integer "sort_key"
     t.integer "import_request_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.boolean "most_recent", null: false
     t.index ["import_request_id", "most_recent"], name: "index_import_request_transitions_parent_most_recent", unique: true, where: "most_recent"
     t.index ["import_request_id"], name: "index_import_request_transitions_on_import_request_id"
@@ -620,8 +620,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.string "isbn"
     t.integer "manifestation_id"
     t.integer "user_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["isbn"], name: "index_import_requests_on_isbn"
     t.index ["manifestation_id"], name: "index_import_requests_on_manifestation_id"
     t.index ["user_id"], name: "index_import_requests_on_user_id"
@@ -631,8 +631,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "item_id"
     t.integer "inventory_file_id"
     t.text "note"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "item_identifier"
     t.string "current_shelf_name"
     t.index ["current_shelf_name"], name: "index_inventories_on_current_shelf_name"
@@ -647,8 +647,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "size"
     t.integer "user_id"
     t.text "note"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "inventory_file_name"
     t.string "inventory_content_type"
     t.integer "inventory_file_size"
@@ -664,8 +664,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name", null: false, comment: "表示名"
     t.text "note", comment: "備考"
     t.integer "position", default: 1, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_item_custom_properties_on_name", unique: true
   end
 
@@ -673,8 +673,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.bigint "item_custom_property_id", null: false
     t.bigint "item_id", null: false
     t.text "value"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["item_custom_property_id", "item_id"], name: "index_item_custom_values_on_custom_item_property_and_item_id", unique: true
     t.index ["item_custom_property_id"], name: "index_item_custom_values_on_custom_property_id"
     t.index ["item_id"], name: "index_item_custom_values_on_item_id"
@@ -683,8 +683,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
   create_table "item_has_use_restrictions", id: :serial, force: :cascade do |t|
     t.integer "item_id", null: false
     t.integer "use_restriction_id", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["item_id"], name: "index_item_has_use_restrictions_on_item_id"
     t.index ["use_restriction_id"], name: "index_item_has_use_restrictions_on_use_restriction_id"
   end
@@ -692,8 +692,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
   create_table "items", id: :serial, force: :cascade do |t|
     t.string "call_number"
     t.string "item_identifier"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "shelf_id", default: 1, null: false
     t.boolean "include_supplements", default: false, null: false
     t.text "note"
@@ -726,8 +726,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
   create_table "jpno_records", force: :cascade do |t|
     t.string "body", null: false
     t.bigint "manifestation_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["body"], name: "index_jpno_records_on_body", unique: true
     t.index ["manifestation_id"], name: "index_jpno_records_on_manifestation_id"
   end
@@ -765,8 +765,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "users_count", default: 0, null: false
     t.integer "position"
     t.integer "country_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.text "opening_hour"
     t.string "isil"
     t.float "latitude"
@@ -795,8 +795,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "note"
     t.integer "country_id"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.text "admin_networks"
     t.boolean "allow_bookmark_external_url", default: false, null: false
     t.string "url", default: "http://localhost:3000/"
@@ -823,8 +823,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.string "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "manifestation_checkout_stat_transitions", id: :serial, force: :cascade do |t|
@@ -832,8 +832,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "metadata", default: "{}"
     t.integer "sort_key"
     t.integer "manifestation_checkout_stat_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.boolean "most_recent", null: false
     t.index ["manifestation_checkout_stat_id", "most_recent"], name: "index_manifestation_checkout_stat_transitions_parent_most_rece", unique: true, where: "most_recent"
     t.index ["manifestation_checkout_stat_id"], name: "index_manifestation_checkout_stat_transitions_on_stat_id"
@@ -844,8 +844,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.datetime "start_date"
     t.datetime "end_date"
     t.text "note"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.datetime "started_at"
     t.datetime "completed_at"
     t.integer "user_id"
@@ -857,8 +857,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name", null: false, comment: "表示名"
     t.text "note", comment: "備考"
     t.integer "position", default: 1, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_manifestation_custom_properties_on_name", unique: true
   end
 
@@ -866,8 +866,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.bigint "manifestation_custom_property_id", null: false
     t.bigint "manifestation_id", null: false
     t.text "value"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["manifestation_custom_property_id", "manifestation_id"], name: "index_manifestation_custom_values_on_property_manifestation", unique: true
     t.index ["manifestation_custom_property_id"], name: "index_manifestation_custom_values_on_custom_property_id"
     t.index ["manifestation_id"], name: "index_manifestation_custom_values_on_manifestation_id"
@@ -878,16 +878,16 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "manifestation_relationships", id: :serial, force: :cascade do |t|
     t.integer "parent_id"
     t.integer "child_id"
     t.integer "manifestation_relationship_type_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "position"
     t.index ["child_id"], name: "index_manifestation_relationships_on_child_id"
     t.index ["parent_id"], name: "index_manifestation_relationships_on_parent_id"
@@ -898,8 +898,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "metadata", default: "{}"
     t.integer "sort_key"
     t.integer "manifestation_reserve_stat_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.boolean "most_recent", null: false
     t.index ["manifestation_reserve_stat_id", "most_recent"], name: "index_manifestation_reserve_stat_transitions_parent_most_recen", unique: true, where: "most_recent"
     t.index ["manifestation_reserve_stat_id"], name: "index_manifestation_reserve_stat_transitions_on_stat_id"
@@ -910,8 +910,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.datetime "start_date"
     t.datetime "end_date"
     t.text "note"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.datetime "started_at"
     t.datetime "completed_at"
     t.integer "user_id"
@@ -926,8 +926,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.string "manifestation_identifier"
     t.datetime "date_of_publication"
     t.datetime "date_copyrighted"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "access_address"
     t.integer "language_id", default: 1, null: false
     t.integer "carrier_type_id", default: 1, null: false
@@ -990,8 +990,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "message_transitions", force: :cascade do |t|
@@ -999,8 +999,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "metadata", default: "{}"
     t.integer "sort_key"
     t.bigint "message_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.boolean "most_recent", null: false
     t.index ["message_id", "most_recent"], name: "index_message_transitions_parent_most_recent", unique: true, where: "most_recent"
     t.index ["message_id"], name: "index_message_transitions_on_message_id"
@@ -1015,8 +1015,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "body"
     t.bigint "message_request_id"
     t.bigint "parent_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "lft"
     t.integer "rgt"
     t.integer "depth"
@@ -1029,8 +1029,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
   create_table "ndl_bib_id_records", force: :cascade do |t|
     t.string "body", null: false
     t.bigint "manifestation_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["body"], name: "index_ndl_bib_id_records_on_body", unique: true
     t.index ["manifestation_id"], name: "index_ndl_bib_id_records_on_manifestation_id"
   end
@@ -1038,8 +1038,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
   create_table "ndla_records", force: :cascade do |t|
     t.bigint "agent_id"
     t.string "body", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["agent_id"], name: "index_ndla_records_on_agent_id"
     t.index ["body"], name: "index_ndla_records_on_body", unique: true
   end
@@ -1050,8 +1050,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.string "url"
     t.text "body"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "news_posts", id: :serial, force: :cascade do |t|
@@ -1064,8 +1064,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "note"
     t.integer "position"
     t.boolean "draft", default: false, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "url"
     t.index ["user_id"], name: "index_news_posts_on_user_id"
   end
@@ -1075,8 +1075,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_nii_types_on_name", unique: true
   end
 
@@ -1084,8 +1084,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "agent_id", null: false
     t.integer "item_id", null: false
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["agent_id"], name: "index_owns_on_agent_id"
     t.index ["item_id"], name: "index_owns_on_item_id"
   end
@@ -1094,8 +1094,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "agent_id", null: false
     t.integer "event_id", null: false
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["agent_id"], name: "index_participates_on_agent_id"
     t.index ["event_id"], name: "index_participates_on_event_id"
   end
@@ -1105,8 +1105,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.string "picture_attachable_type"
     t.text "title"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "picture_file_name"
     t.string "picture_content_type"
     t.integer "picture_file_size"
@@ -1124,8 +1124,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "country_id"
     t.float "latitude"
     t.float "longitude"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["country_id"], name: "index_places_on_country_id"
     t.index ["term"], name: "index_places_on_term"
   end
@@ -1135,16 +1135,16 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "produces", id: :serial, force: :cascade do |t|
     t.integer "agent_id", null: false
     t.integer "manifestation_id", null: false
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "produce_type_id"
     t.index ["agent_id"], name: "index_produces_on_agent_id"
     t.index ["manifestation_id"], name: "index_produces_on_manifestation_id"
@@ -1160,8 +1160,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "note"
     t.text "keyword_list"
     t.integer "required_role_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "checkout_icalendar_token"
     t.boolean "save_checkout_history", default: false, null: false
     t.datetime "expired_at"
@@ -1180,16 +1180,16 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "realizes", id: :serial, force: :cascade do |t|
     t.integer "agent_id", null: false
     t.integer "expression_id", null: false
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "realize_type_id"
     t.index ["agent_id"], name: "index_realizes_on_agent_id"
     t.index ["expression_id"], name: "index_realizes_on_expression_id"
@@ -1200,8 +1200,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "request_types", id: :serial, force: :cascade do |t|
@@ -1209,16 +1209,16 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "reserve_stat_has_manifestations", id: :serial, force: :cascade do |t|
     t.integer "manifestation_reserve_stat_id", null: false
     t.integer "manifestation_id", null: false
     t.integer "reserves_count"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["manifestation_id"], name: "index_reserve_stat_has_manifestations_on_manifestation_id"
     t.index ["manifestation_reserve_stat_id"], name: "index_reserve_stat_has_manifestations_on_m_reserve_stat_id"
   end
@@ -1227,8 +1227,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "user_reserve_stat_id", null: false
     t.integer "user_id", null: false
     t.integer "reserves_count"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_reserve_stat_has_users_on_user_id"
     t.index ["user_reserve_stat_id"], name: "index_reserve_stat_has_users_on_user_reserve_stat_id"
   end
@@ -1238,8 +1238,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "metadata", default: "{}"
     t.integer "sort_key"
     t.integer "reserve_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.boolean "most_recent", null: false
     t.index ["reserve_id", "most_recent"], name: "index_reserve_transitions_parent_most_recent", unique: true, where: "most_recent"
     t.index ["reserve_id"], name: "index_reserve_transitions_on_reserve_id"
@@ -1252,8 +1252,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "item_id"
     t.integer "request_status_type_id", null: false
     t.datetime "checked_out_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.datetime "canceled_at"
     t.datetime "expired_at"
     t.boolean "expiration_notice_to_patron", default: false
@@ -1273,8 +1273,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "metadata", default: "{}"
     t.integer "sort_key"
     t.integer "resource_export_file_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.boolean "most_recent", null: false
     t.index ["resource_export_file_id", "most_recent"], name: "index_resource_export_file_transitions_parent_most_recent", unique: true, where: "most_recent"
     t.index ["resource_export_file_id"], name: "index_resource_export_file_transitions_on_file_id"
@@ -1288,8 +1288,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.bigint "resource_export_file_size"
     t.datetime "resource_export_updated_at"
     t.datetime "executed_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "resource_import_file_transitions", id: :serial, force: :cascade do |t|
@@ -1297,8 +1297,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "metadata", default: "{}"
     t.integer "sort_key"
     t.integer "resource_import_file_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.boolean "most_recent", null: false
     t.index ["resource_import_file_id", "most_recent"], name: "index_resource_import_file_transitions_parent_most_recent", unique: true, where: "most_recent"
     t.index ["resource_import_file_id"], name: "index_resource_import_file_transitions_on_file_id"
@@ -1316,8 +1316,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.string "resource_import_content_type"
     t.integer "resource_import_file_size"
     t.datetime "resource_import_updated_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "edit_mode"
     t.string "resource_import_fingerprint"
     t.text "error_message"
@@ -1332,8 +1332,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "manifestation_id"
     t.integer "item_id"
     t.text "body"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.text "error_message"
     t.index ["item_id"], name: "index_resource_import_results_on_item_id"
     t.index ["manifestation_id"], name: "index_resource_import_results_on_manifestation_id"
@@ -1344,8 +1344,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.string "name", null: false
     t.string "display_name"
     t.text "note"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "score", default: 0, null: false
     t.integer "position"
   end
@@ -1360,21 +1360,21 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "additional_param"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "series_statement_merge_lists", id: :serial, force: :cascade do |t|
     t.string "title"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "series_statement_merges", id: :serial, force: :cascade do |t|
     t.integer "series_statement_id", null: false
     t.integer "series_statement_merge_list_id", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["series_statement_id"], name: "index_series_statement_merges_on_series_statement_id"
     t.index ["series_statement_merge_list_id"], name: "index_series_statement_merges_on_list_id"
   end
@@ -1385,8 +1385,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "title_subseries"
     t.text "numbering_subseries"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.text "title_transcription"
     t.text "title_alternative"
     t.string "series_statement_identifier"
@@ -1410,8 +1410,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "library_id", null: false
     t.integer "items_count", default: 0, null: false
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.boolean "closed", default: false, null: false
     t.index ["library_id"], name: "index_shelves_on_library_id"
   end
@@ -1421,8 +1421,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "subject_types", id: :serial, force: :cascade do |t|
@@ -1430,8 +1430,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "subjects", id: :serial, force: :cascade do |t|
@@ -1444,8 +1444,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "note"
     t.integer "required_role_id", default: 1, null: false
     t.integer "lock_version", default: 0, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "url"
     t.integer "manifestation_id"
     t.integer "subject_heading_type_id"
@@ -1462,8 +1462,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "work_id", null: false
     t.datetime "start_at", null: false
     t.datetime "end_at", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["subscription_id"], name: "index_subscribes_on_subscription_id"
     t.index ["work_id"], name: "index_subscribes_on_work_id"
   end
@@ -1474,8 +1474,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "user_id"
     t.integer "order_list_id"
     t.integer "subscribes_count", default: 0, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["order_list_id"], name: "index_subscriptions_on_order_list_id"
     t.index ["user_id"], name: "index_subscriptions_on_user_id"
   end
@@ -1487,7 +1487,7 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.string "tagger_type"
     t.integer "tagger_id"
     t.string "context", limit: 128
-    t.datetime "created_at"
+    t.datetime "created_at", precision: 6, null: false
     t.index ["context"], name: "index_taggings_on_context"
     t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
     t.index ["tag_id"], name: "index_taggings_on_tag_id"
@@ -1502,8 +1502,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
   create_table "tags", id: :serial, force: :cascade do |t|
     t.string "name"
     t.integer "taggings_count", default: 0
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
@@ -1512,8 +1512,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "user_checkout_stat_transitions", id: :serial, force: :cascade do |t|
@@ -1521,8 +1521,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "metadata", default: "{}"
     t.integer "sort_key"
     t.integer "user_checkout_stat_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.boolean "most_recent", null: false
     t.index ["sort_key", "user_checkout_stat_id"], name: "index_user_checkout_stat_transitions_on_sort_key_and_stat_id", unique: true
     t.index ["user_checkout_stat_id", "most_recent"], name: "index_user_checkout_stat_transitions_parent_most_recent", unique: true, where: "most_recent"
@@ -1533,8 +1533,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.datetime "start_date"
     t.datetime "end_date"
     t.text "note"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.datetime "started_at"
     t.datetime "completed_at"
     t.integer "user_id"
@@ -1546,8 +1546,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "metadata", default: "{}"
     t.integer "sort_key"
     t.integer "user_export_file_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.boolean "most_recent", null: false
     t.index ["sort_key", "user_export_file_id"], name: "index_user_export_file_transitions_on_sort_key_and_file_id", unique: true
     t.index ["user_export_file_id", "most_recent"], name: "index_user_export_file_transitions_parent_most_recent", unique: true, where: "most_recent"
@@ -1562,8 +1562,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.bigint "user_export_file_size"
     t.datetime "user_export_updated_at"
     t.datetime "executed_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_user_export_files_on_user_id"
   end
 
@@ -1579,8 +1579,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.datetime "fixed_due_date"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "current_checkout_count"
     t.index ["checkout_type_id"], name: "index_user_group_has_checkout_types_on_checkout_type_id"
     t.index ["user_group_id"], name: "index_user_group_has_checkout_types_on_user_group_id"
@@ -1591,8 +1591,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "display_name"
     t.text "note"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "valid_period_for_new_user", default: 0, null: false
     t.datetime "expired_at"
     t.integer "number_of_day_to_notify_overdue", default: 0, null: false
@@ -1603,8 +1603,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
   create_table "user_has_roles", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "role_id", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["role_id"], name: "index_user_has_roles_on_role_id"
     t.index ["user_id"], name: "index_user_has_roles_on_user_id"
   end
@@ -1614,8 +1614,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "metadata", default: "{}"
     t.integer "sort_key"
     t.integer "user_import_file_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.boolean "most_recent", null: false
     t.index ["sort_key", "user_import_file_id"], name: "index_user_import_file_transitions_on_sort_key_and_file_id", unique: true
     t.index ["user_import_file_id", "most_recent"], name: "index_user_import_file_transitions_parent_most_recent", unique: true, where: "most_recent"
@@ -1633,8 +1633,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.string "user_import_fingerprint"
     t.string "edit_mode"
     t.text "error_message"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "user_encoding"
     t.integer "default_library_id"
     t.integer "default_user_group_id"
@@ -1645,8 +1645,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "user_import_file_id"
     t.integer "user_id"
     t.text "body"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.text "error_message"
     t.index ["user_id"], name: "index_user_import_results_on_user_id"
     t.index ["user_import_file_id"], name: "index_user_import_results_on_user_import_file_id"
@@ -1657,8 +1657,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.text "metadata", default: "{}"
     t.integer "sort_key"
     t.integer "user_reserve_stat_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.boolean "most_recent", null: false
     t.index ["sort_key", "user_reserve_stat_id"], name: "index_user_reserve_stat_transitions_on_sort_key_and_stat_id", unique: true
     t.index ["user_reserve_stat_id", "most_recent"], name: "index_user_reserve_stat_transitions_parent_most_recent", unique: true, where: "most_recent"
@@ -1669,8 +1669,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.datetime "start_date"
     t.datetime "end_date"
     t.text "note"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.datetime "started_at"
     t.datetime "completed_at"
     t.integer "user_id"
@@ -1683,8 +1683,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "username"
     t.datetime "expired_at"
     t.integer "failed_attempts", default: 0
@@ -1701,8 +1701,8 @@ ActiveRecord::Schema.define(version: 2022_05_07_153151) do
     t.integer "basket_id"
     t.integer "item_id"
     t.integer "librarian_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["basket_id"], name: "index_withdraws_on_basket_id"
     t.index ["item_id"], name: "index_withdraws_on_item_id"
     t.index ["librarian_id"], name: "index_withdraws_on_librarian_id"

--- a/spec/factories/accepts.rb
+++ b/spec/factories/accepts.rb
@@ -16,6 +16,6 @@ end
 #  basket_id    :integer
 #  item_id      :integer
 #  librarian_id :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/agent_merge_lists.rb
+++ b/spec/factories/agent_merge_lists.rb
@@ -10,6 +10,6 @@ end
 #
 #  id         :integer          not null, primary key
 #  title      :string
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/spec/factories/agent_merges.rb
+++ b/spec/factories/agent_merges.rb
@@ -12,6 +12,6 @@ end
 #  id                  :integer          not null, primary key
 #  agent_id            :integer          not null
 #  agent_merge_list_id :integer          not null
-#  created_at          :datetime
-#  updated_at          :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #

--- a/spec/factories/agent_relationship_types.rb
+++ b/spec/factories/agent_relationship_types.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/agent_relationships.rb
+++ b/spec/factories/agent_relationships.rb
@@ -14,7 +14,7 @@ end
 #  parent_id                  :integer
 #  child_id                   :integer
 #  agent_relationship_type_id :integer
-#  created_at                 :datetime
-#  updated_at                 :datetime
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
 #  position                   :integer
 #

--- a/spec/factories/agent_types.rb
+++ b/spec/factories/agent_types.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/agents.rb
+++ b/spec/factories/agents.rb
@@ -28,8 +28,8 @@ end
 #  full_name                           :string
 #  full_name_transcription             :text
 #  full_name_alternative               :text
-#  created_at                          :datetime
-#  updated_at                          :datetime
+#  created_at                          :datetime         not null
+#  updated_at                          :datetime         not null
 #  zip_code_1                          :string
 #  zip_code_2                          :string
 #  address_1                           :text

--- a/spec/factories/baskets.rb
+++ b/spec/factories/baskets.rb
@@ -12,6 +12,6 @@ end
 #  user_id      :integer
 #  note         :text
 #  lock_version :integer          default(0), not null
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/bookmark_stats.rb
+++ b/spec/factories/bookmark_stats.rb
@@ -15,6 +15,6 @@ end
 #  started_at   :datetime
 #  completed_at :datetime
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/bookmarks.rb
+++ b/spec/factories/bookmarks.rb
@@ -18,6 +18,6 @@ end
 #  url              :string
 #  note             :text
 #  shared           :boolean
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/factories/bookstores.rb
+++ b/spec/factories/bookstores.rb
@@ -17,6 +17,6 @@ end
 #  fax_number       :string
 #  url              :string
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/factories/budget_types.rb
+++ b/spec/factories/budget_types.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/carrier_type_has_checkout_types.rb
+++ b/spec/factories/carrier_type_has_checkout_types.rb
@@ -14,6 +14,6 @@ end
 #  checkout_type_id :integer          not null
 #  note             :text
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/factories/carrier_types.rb
+++ b/spec/factories/carrier_types.rb
@@ -13,8 +13,8 @@ end
 #  display_name            :text
 #  note                    :text
 #  position                :integer
-#  created_at              :datetime
-#  updated_at              :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #  attachment_file_name    :string
 #  attachment_content_type :string
 #  attachment_file_size    :bigint

--- a/spec/factories/checkout_types.rb
+++ b/spec/factories/checkout_types.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/checkouts.rb
+++ b/spec/factories/checkouts.rb
@@ -21,8 +21,8 @@ end
 #  due_date               :datetime
 #  checkout_renewal_count :integer          default(0), not null
 #  lock_version           :integer          default(0), not null
-#  created_at             :datetime
-#  updated_at             :datetime
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
 #  shelf_id               :integer
 #  library_id             :integer
 #

--- a/spec/factories/circulation_statuses.rb
+++ b/spec/factories/circulation_statuses.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/classification_types.rb
+++ b/spec/factories/classification_types.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/classifications.rb
+++ b/spec/factories/classifications.rb
@@ -14,8 +14,8 @@ end
 #  category               :string           not null
 #  note                   :text
 #  classification_type_id :integer          not null
-#  created_at             :datetime
-#  updated_at             :datetime
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
 #  lft                    :integer
 #  rgt                    :integer
 #  manifestation_id       :integer

--- a/spec/factories/content_types.rb
+++ b/spec/factories/content_types.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/create_types.rb
+++ b/spec/factories/create_types.rb
@@ -17,6 +17,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/creates.rb
+++ b/spec/factories/creates.rb
@@ -14,7 +14,7 @@ end
 #  agent_id       :integer          not null
 #  work_id        :integer          not null
 #  position       :integer
-#  created_at     :datetime
-#  updated_at     :datetime
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
 #  create_type_id :integer
 #

--- a/spec/factories/donates.rb
+++ b/spec/factories/donates.rb
@@ -12,6 +12,6 @@ end
 #  id         :integer          not null, primary key
 #  agent_id   :integer          not null
 #  item_id    :integer          not null
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/spec/factories/event_categories.rb
+++ b/spec/factories/event_categories.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -21,7 +21,7 @@ end
 #  end_at            :datetime
 #  all_day           :boolean          default(FALSE), not null
 #  display_name      :text
-#  created_at        :datetime
-#  updated_at        :datetime
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #  place_id          :integer
 #

--- a/spec/factories/form_of_works.rb
+++ b/spec/factories/form_of_works.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/frequencies.rb
+++ b/spec/factories/frequencies.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/identifier_types.rb
+++ b/spec/factories/identifier_types.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/identifiers.rb
+++ b/spec/factories/identifiers.rb
@@ -16,6 +16,6 @@ end
 #  manifestation_id   :integer
 #  primary            :boolean
 #  position           :integer
-#  created_at         :datetime
-#  updated_at         :datetime
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #

--- a/spec/factories/import_requests.rb
+++ b/spec/factories/import_requests.rb
@@ -13,6 +13,6 @@ end
 #  isbn             :string
 #  manifestation_id :integer
 #  user_id          :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/factories/item_has_use_restrictions.rb
+++ b/spec/factories/item_has_use_restrictions.rb
@@ -12,6 +12,6 @@ end
 #  id                 :integer          not null, primary key
 #  item_id            :integer          not null
 #  use_restriction_id :integer          not null
-#  created_at         :datetime
-#  updated_at         :datetime
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -18,8 +18,8 @@ end
 #  id                      :integer          not null, primary key
 #  call_number             :string
 #  item_identifier         :string
-#  created_at              :datetime
-#  updated_at              :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #  shelf_id                :integer          default(1), not null
 #  include_supplements     :boolean          default(FALSE), not null
 #  note                    :text

--- a/spec/factories/libraries.rb
+++ b/spec/factories/libraries.rb
@@ -34,8 +34,8 @@ end
 #  users_count           :integer          default(0), not null
 #  position              :integer
 #  country_id            :integer
-#  created_at            :datetime
-#  updated_at            :datetime
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
 #  opening_hour          :text
 #  isil                  :string
 #  latitude              :float

--- a/spec/factories/licenses.rb
+++ b/spec/factories/licenses.rb
@@ -13,6 +13,6 @@ end
 #  display_name :string
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/manifestation_checkout_stats.rb
+++ b/spec/factories/manifestation_checkout_stats.rb
@@ -14,8 +14,8 @@ end
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  started_at   :datetime
 #  completed_at :datetime
 #  user_id      :integer

--- a/spec/factories/manifestation_relationship_types.rb
+++ b/spec/factories/manifestation_relationship_types.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/manifestation_relationships.rb
+++ b/spec/factories/manifestation_relationships.rb
@@ -14,7 +14,7 @@ end
 #  parent_id                          :integer
 #  child_id                           :integer
 #  manifestation_relationship_type_id :integer
-#  created_at                         :datetime
-#  updated_at                         :datetime
+#  created_at                         :datetime         not null
+#  updated_at                         :datetime         not null
 #  position                           :integer
 #

--- a/spec/factories/manifestation_reserve_stats.rb
+++ b/spec/factories/manifestation_reserve_stats.rb
@@ -14,8 +14,8 @@ end
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  started_at   :datetime
 #  completed_at :datetime
 #  user_id      :integer

--- a/spec/factories/manifestations.rb
+++ b/spec/factories/manifestations.rb
@@ -25,8 +25,8 @@ end
 #  manifestation_identifier        :string
 #  date_of_publication             :datetime
 #  date_copyrighted                :datetime
-#  created_at                      :datetime
-#  updated_at                      :datetime
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
 #  access_address                  :string
 #  language_id                     :integer          default(1), not null
 #  carrier_type_id                 :integer          default(1), not null

--- a/spec/factories/medium_of_performances.rb
+++ b/spec/factories/medium_of_performances.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/news_feeds.rb
+++ b/spec/factories/news_feeds.rb
@@ -15,6 +15,6 @@ end
 #  url              :string
 #  body             :text
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/factories/news_posts.rb
+++ b/spec/factories/news_posts.rb
@@ -20,7 +20,7 @@ end
 #  note             :text
 #  position         :integer
 #  draft            :boolean          default(FALSE), not null
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #  url              :string
 #

--- a/spec/factories/owns.rb
+++ b/spec/factories/owns.rb
@@ -13,6 +13,6 @@ end
 #  agent_id   :integer          not null
 #  item_id    :integer          not null
 #  position   :integer
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/spec/factories/participates.rb
+++ b/spec/factories/participates.rb
@@ -13,6 +13,6 @@ end
 #  agent_id   :integer          not null
 #  event_id   :integer          not null
 #  position   :integer
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/spec/factories/produce_types.rb
+++ b/spec/factories/produce_types.rb
@@ -17,6 +17,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/produces.rb
+++ b/spec/factories/produces.rb
@@ -13,7 +13,7 @@ end
 #  agent_id         :integer          not null
 #  manifestation_id :integer          not null
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #  produce_type_id  :integer
 #

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -30,8 +30,8 @@ end
 #  note                     :text
 #  keyword_list             :text
 #  required_role_id         :integer
-#  created_at               :datetime
-#  updated_at               :datetime
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
 #  checkout_icalendar_token :string
 #  save_checkout_history    :boolean          default(FALSE), not null
 #  expired_at               :datetime

--- a/spec/factories/realize_types.rb
+++ b/spec/factories/realize_types.rb
@@ -17,6 +17,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/realizes.rb
+++ b/spec/factories/realizes.rb
@@ -13,7 +13,7 @@ end
 #  agent_id        :integer          not null
 #  expression_id   :integer          not null
 #  position        :integer
-#  created_at      :datetime
-#  updated_at      :datetime
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
 #  realize_type_id :integer
 #

--- a/spec/factories/request_status_types.rb
+++ b/spec/factories/request_status_types.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/request_types.rb
+++ b/spec/factories/request_types.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/reserves.rb
+++ b/spec/factories/reserves.rb
@@ -24,8 +24,8 @@ end
 #  item_id                      :integer
 #  request_status_type_id       :integer          not null
 #  checked_out_at               :datetime
-#  created_at                   :datetime
-#  updated_at                   :datetime
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
 #  canceled_at                  :datetime
 #  expired_at                   :datetime
 #  expiration_notice_to_patron  :boolean          default(FALSE)

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -16,8 +16,8 @@ end
 #  name         :string           not null
 #  display_name :string
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  score        :integer          default(0), not null
 #  position     :integer
 #

--- a/spec/factories/search_engines.rb
+++ b/spec/factories/search_engines.rb
@@ -22,6 +22,6 @@ end
 #  additional_param :text
 #  note             :text
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/factories/series_statement_merge_lists.rb
+++ b/spec/factories/series_statement_merge_lists.rb
@@ -10,6 +10,6 @@ end
 #
 #  id         :integer          not null, primary key
 #  title      :string
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/spec/factories/series_statement_merges.rb
+++ b/spec/factories/series_statement_merges.rb
@@ -12,6 +12,6 @@ end
 #  id                             :integer          not null, primary key
 #  series_statement_id            :integer          not null
 #  series_statement_merge_list_id :integer          not null
-#  created_at                     :datetime
-#  updated_at                     :datetime
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
 #

--- a/spec/factories/series_statements.rb
+++ b/spec/factories/series_statements.rb
@@ -21,8 +21,8 @@ end
 #  title_subseries                    :text
 #  numbering_subseries                :text
 #  position                           :integer
-#  created_at                         :datetime
-#  updated_at                         :datetime
+#  created_at                         :datetime         not null
+#  updated_at                         :datetime         not null
 #  title_transcription                :text
 #  title_alternative                  :text
 #  series_statement_identifier        :string

--- a/spec/factories/shelves.rb
+++ b/spec/factories/shelves.rb
@@ -16,7 +16,7 @@ end
 #  library_id   :integer          not null
 #  items_count  :integer          default(0), not null
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  closed       :boolean          default(FALSE), not null
 #

--- a/spec/factories/subject_heading_types.rb
+++ b/spec/factories/subject_heading_types.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/subject_types.rb
+++ b/spec/factories/subject_types.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -20,8 +20,8 @@ end
 #  note                    :text
 #  required_role_id        :integer          default(1), not null
 #  lock_version            :integer          default(0), not null
-#  created_at              :datetime
-#  updated_at              :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #  url                     :string
 #  manifestation_id        :integer
 #  subject_heading_type_id :integer

--- a/spec/factories/subscribes.rb
+++ b/spec/factories/subscribes.rb
@@ -16,6 +16,6 @@ end
 #  work_id         :integer          not null
 #  start_at        :datetime         not null
 #  end_at          :datetime         not null
-#  created_at      :datetime
-#  updated_at      :datetime
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
 #

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -15,6 +15,6 @@ end
 #  user_id          :integer
 #  order_list_id    :integer
 #  subscribes_count :integer          default(0), not null
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -11,6 +11,6 @@ end
 #  id             :integer          not null, primary key
 #  name           :string
 #  taggings_count :integer          default(0)
-#  created_at     :datetime
-#  updated_at     :datetime
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
 #

--- a/spec/factories/use_restrictions.rb
+++ b/spec/factories/use_restrictions.rb
@@ -13,6 +13,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/factories/user_checkout_stats.rb
+++ b/spec/factories/user_checkout_stats.rb
@@ -14,8 +14,8 @@ end
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  started_at   :datetime
 #  completed_at :datetime
 #  user_id      :integer

--- a/spec/factories/user_group_has_checkout_types.rb
+++ b/spec/factories/user_group_has_checkout_types.rb
@@ -21,7 +21,7 @@ end
 #  fixed_due_date                  :datetime
 #  note                            :text
 #  position                        :integer
-#  created_at                      :datetime
-#  updated_at                      :datetime
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
 #  current_checkout_count          :integer
 #

--- a/spec/factories/user_groups.rb
+++ b/spec/factories/user_groups.rb
@@ -13,8 +13,8 @@ end
 #  display_name                     :text
 #  note                             :text
 #  position                         :integer
-#  created_at                       :datetime
-#  updated_at                       :datetime
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
 #  valid_period_for_new_user        :integer          default(0), not null
 #  expired_at                       :datetime
 #  number_of_day_to_notify_overdue  :integer          default(0), not null

--- a/spec/factories/user_reserve_stats.rb
+++ b/spec/factories/user_reserve_stats.rb
@@ -14,8 +14,8 @@ end
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  started_at   :datetime
 #  completed_at :datetime
 #  user_id      :integer

--- a/spec/fixtures/accepts.yml
+++ b/spec/fixtures/accepts.yml
@@ -16,6 +16,6 @@ two:
 #  basket_id    :integer
 #  item_id      :integer
 #  librarian_id :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/fixtures/agent_import_files.yml
+++ b/spec/fixtures/agent_import_files.yml
@@ -34,8 +34,8 @@ agent_import_file_00003:
 #  agent_import_content_type :string
 #  agent_import_file_size    :integer
 #  agent_import_updated_at   :datetime
-#  created_at                :datetime
-#  updated_at                :datetime
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
 #  agent_import_fingerprint  :string
 #  error_message             :text
 #  edit_mode                 :string

--- a/spec/fixtures/agent_import_results.yml
+++ b/spec/fixtures/agent_import_results.yml
@@ -20,6 +20,6 @@ two:
 #  agent_import_file_id :integer
 #  agent_id             :integer
 #  body                 :text
-#  created_at           :datetime
-#  updated_at           :datetime
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
 #

--- a/spec/fixtures/agent_merge_lists.yml
+++ b/spec/fixtures/agent_merge_lists.yml
@@ -21,6 +21,6 @@ agent_merge_list_00003:
 #
 #  id         :integer          not null, primary key
 #  title      :string
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/spec/fixtures/agent_merges.yml
+++ b/spec/fixtures/agent_merges.yml
@@ -25,6 +25,6 @@ agent_merge_00003:
 #  id                  :integer          not null, primary key
 #  agent_id            :integer          not null
 #  agent_merge_list_id :integer          not null
-#  created_at          :datetime
-#  updated_at          :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #

--- a/spec/fixtures/agent_relationship_types.yml
+++ b/spec/fixtures/agent_relationship_types.yml
@@ -28,6 +28,6 @@ agent_relationship_type_00003:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/fixtures/agent_relationships.yml
+++ b/spec/fixtures/agent_relationships.yml
@@ -18,7 +18,7 @@ two:
 #  parent_id                  :integer
 #  child_id                   :integer
 #  agent_relationship_type_id :integer
-#  created_at                 :datetime
-#  updated_at                 :datetime
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
 #  position                   :integer
 #

--- a/spec/fixtures/agent_types.yml
+++ b/spec/fixtures/agent_types.yml
@@ -29,6 +29,6 @@ agent_type_00003:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/fixtures/agents.yml
+++ b/spec/fixtures/agents.yml
@@ -288,8 +288,8 @@ agent_00202:
 #  full_name                           :string
 #  full_name_transcription             :text
 #  full_name_alternative               :text
-#  created_at                          :datetime
-#  updated_at                          :datetime
+#  created_at                          :datetime         not null
+#  updated_at                          :datetime         not null
 #  zip_code_1                          :string
 #  zip_code_2                          :string
 #  address_1                           :text

--- a/spec/fixtures/baskets.yml
+++ b/spec/fixtures/baskets.yml
@@ -74,7 +74,7 @@ basket_00011:
 #  user_id      :integer
 #  note         :text
 #  lock_version :integer          default(0), not null
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #
 

--- a/spec/fixtures/bookmark_stat_has_manifestations.yml
+++ b/spec/fixtures/bookmark_stat_has_manifestations.yml
@@ -18,6 +18,6 @@ two:
 #  bookmark_stat_id :integer          not null
 #  manifestation_id :integer          not null
 #  bookmarks_count  :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/fixtures/bookmark_stats.yml
+++ b/spec/fixtures/bookmark_stats.yml
@@ -22,6 +22,6 @@ bookmark_stat_00002:
 #  started_at   :datetime
 #  completed_at :datetime
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/fixtures/bookmarks.yml
+++ b/spec/fixtures/bookmarks.yml
@@ -51,6 +51,6 @@ bookmark_00005:
 #  url              :string
 #  note             :text
 #  shared           :boolean
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/fixtures/bookstores.yml
+++ b/spec/fixtures/bookstores.yml
@@ -83,7 +83,7 @@ bookstore_00007:
 #  fax_number       :string
 #  url              :string
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #
 

--- a/spec/fixtures/budget_types.yml
+++ b/spec/fixtures/budget_types.yml
@@ -23,7 +23,7 @@ donation:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #
 

--- a/spec/fixtures/carrier_type_has_checkout_types.yml
+++ b/spec/fixtures/carrier_type_has_checkout_types.yml
@@ -25,6 +25,6 @@ carrier_type_has_checkout_type_00003:
 #  checkout_type_id :integer          not null
 #  note             :text
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/fixtures/carrier_types.yml
+++ b/spec/fixtures/carrier_types.yml
@@ -41,8 +41,8 @@ carrier_type_00004:
 #  display_name            :text
 #  note                    :text
 #  position                :integer
-#  created_at              :datetime
-#  updated_at              :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #  attachment_file_name    :string
 #  attachment_content_type :string
 #  attachment_file_size    :bigint

--- a/spec/fixtures/checked_items.yml
+++ b/spec/fixtures/checked_items.yml
@@ -29,7 +29,7 @@ checked_item_00004:
 #  basket_id    :integer          not null
 #  librarian_id :integer
 #  due_date     :datetime         not null
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  user_id      :integer
 #

--- a/spec/fixtures/checkins.yml
+++ b/spec/fixtures/checkins.yml
@@ -48,7 +48,7 @@ checkin_00005:
 #  item_id      :integer          not null
 #  librarian_id :integer
 #  basket_id    :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  lock_version :integer          default(0), not null
 #

--- a/spec/fixtures/checkout_stat_has_manifestations.yml
+++ b/spec/fixtures/checkout_stat_has_manifestations.yml
@@ -18,6 +18,6 @@ two:
 #  manifestation_checkout_stat_id :integer          not null
 #  manifestation_id               :integer          not null
 #  checkouts_count                :integer
-#  created_at                     :datetime
-#  updated_at                     :datetime
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
 #

--- a/spec/fixtures/checkout_stat_has_users.yml
+++ b/spec/fixtures/checkout_stat_has_users.yml
@@ -18,6 +18,6 @@ two:
 #  user_checkout_stat_id :integer          not null
 #  user_id               :integer          not null
 #  checkouts_count       :integer          default(0), not null
-#  created_at            :datetime
-#  updated_at            :datetime
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
 #

--- a/spec/fixtures/checkout_types.yml
+++ b/spec/fixtures/checkout_types.yml
@@ -28,6 +28,6 @@ checkout_type_00003:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/fixtures/checkouts.yml
+++ b/spec/fixtures/checkouts.yml
@@ -169,8 +169,8 @@ checkout_00014:
 #  due_date               :datetime
 #  checkout_renewal_count :integer          default(0), not null
 #  lock_version           :integer          default(0), not null
-#  created_at             :datetime
-#  updated_at             :datetime
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
 #  shelf_id               :integer
 #  library_id             :integer
 #

--- a/spec/fixtures/circulation_statuses.yml
+++ b/spec/fixtures/circulation_statuses.yml
@@ -114,6 +114,6 @@ circulation_status_00016:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/fixtures/classification_types.yml
+++ b/spec/fixtures/classification_types.yml
@@ -57,7 +57,7 @@ classification_type_00006:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #
 

--- a/spec/fixtures/classifications.yml
+++ b/spec/fixtures/classifications.yml
@@ -110,8 +110,8 @@ classification_00005:
 #  category               :string           not null
 #  note                   :text
 #  classification_type_id :integer          not null
-#  created_at             :datetime
-#  updated_at             :datetime
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
 #  lft                    :integer
 #  rgt                    :integer
 #  manifestation_id       :integer

--- a/spec/fixtures/colors.yml
+++ b/spec/fixtures/colors.yml
@@ -33,6 +33,6 @@ color_00004:
 #  property         :string
 #  code             :string
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/fixtures/content_types.yml
+++ b/spec/fixtures/content_types.yml
@@ -93,6 +93,6 @@ content_type_00012:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/fixtures/create_types.yml
+++ b/spec/fixtures/create_types.yml
@@ -41,6 +41,6 @@ illustrator:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/fixtures/creates.yml
+++ b/spec/fixtures/creates.yml
@@ -59,7 +59,7 @@ create_00104:
 #  agent_id       :integer          not null
 #  work_id        :integer          not null
 #  position       :integer
-#  created_at     :datetime
-#  updated_at     :datetime
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
 #  create_type_id :integer
 #

--- a/spec/fixtures/donates.yml
+++ b/spec/fixtures/donates.yml
@@ -25,6 +25,6 @@ donate_00003:
 #  id         :integer          not null, primary key
 #  agent_id   :integer          not null
 #  item_id    :integer          not null
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/spec/fixtures/event_categories.yml
+++ b/spec/fixtures/event_categories.yml
@@ -49,7 +49,7 @@ event_category_00001:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #
 

--- a/spec/fixtures/event_export_files.yml
+++ b/spec/fixtures/event_export_files.yml
@@ -21,6 +21,6 @@ event_export_file_00003:
 #  event_export_file_size    :bigint
 #  event_export_updated_at   :datetime
 #  executed_at               :datetime
-#  created_at                :datetime
-#  updated_at                :datetime
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
 #

--- a/spec/fixtures/event_import_files.yml
+++ b/spec/fixtures/event_import_files.yml
@@ -35,8 +35,8 @@ event_import_file_00003:
 #  event_import_file_size    :integer
 #  event_import_updated_at   :datetime
 #  edit_mode                 :string
-#  created_at                :datetime
-#  updated_at                :datetime
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
 #  event_import_fingerprint  :string
 #  error_message             :text
 #  user_encoding             :string

--- a/spec/fixtures/event_import_results.yml
+++ b/spec/fixtures/event_import_results.yml
@@ -20,6 +20,6 @@ two:
 #  event_import_file_id :integer
 #  event_id             :integer
 #  body                 :text
-#  created_at           :datetime
-#  updated_at           :datetime
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
 #

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -101,8 +101,8 @@ event_00008:
 #  end_at            :datetime
 #  all_day           :boolean          default(FALSE), not null
 #  display_name      :text
-#  created_at        :datetime
-#  updated_at        :datetime
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #  place_id          :integer
 #
 

--- a/spec/fixtures/form_of_works.yml
+++ b/spec/fixtures/form_of_works.yml
@@ -33,6 +33,6 @@ form_of_work_00003:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/fixtures/frequencies.yml
+++ b/spec/fixtures/frequencies.yml
@@ -63,6 +63,6 @@ frequency_00009:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/fixtures/identifier_types.yml
+++ b/spec/fixtures/identifier_types.yml
@@ -65,7 +65,7 @@ identifier_type_00007:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #
 

--- a/spec/fixtures/identifiers.yml
+++ b/spec/fixtures/identifiers.yml
@@ -129,6 +129,6 @@ identifier_00004a:
 #  manifestation_id   :integer
 #  primary            :boolean
 #  position           :integer
-#  created_at         :datetime
-#  updated_at         :datetime
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #

--- a/spec/fixtures/import_requests.yml
+++ b/spec/fixtures/import_requests.yml
@@ -18,6 +18,6 @@ two:
 #  isbn             :string
 #  manifestation_id :integer
 #  user_id          :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/fixtures/inventories.yml
+++ b/spec/fixtures/inventories.yml
@@ -20,8 +20,8 @@ inventory_00002:
 #  item_id            :integer
 #  inventory_file_id  :integer
 #  note               :text
-#  created_at         :datetime
-#  updated_at         :datetime
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #  item_identifier    :string
 #  current_shelf_name :string
 #

--- a/spec/fixtures/inventory_files.yml
+++ b/spec/fixtures/inventory_files.yml
@@ -29,8 +29,8 @@ inventory_file_00003:
 #  size                   :integer
 #  user_id                :integer
 #  note                   :text
-#  created_at             :datetime
-#  updated_at             :datetime
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
 #  inventory_file_name    :string
 #  inventory_content_type :string
 #  inventory_file_size    :integer

--- a/spec/fixtures/item_has_use_restrictions.yml
+++ b/spec/fixtures/item_has_use_restrictions.yml
@@ -73,6 +73,6 @@ item_has_use_restriction_00011:
 #  id                 :integer          not null, primary key
 #  item_id            :integer          not null
 #  use_restriction_id :integer          not null
-#  created_at         :datetime
-#  updated_at         :datetime
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #

--- a/spec/fixtures/items.yml
+++ b/spec/fixtures/items.yml
@@ -295,8 +295,8 @@ item_00026:
 #  id                      :integer          not null, primary key
 #  call_number             :string
 #  item_identifier         :string
-#  created_at              :datetime
-#  updated_at              :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #  shelf_id                :integer          default(1), not null
 #  include_supplements     :boolean          default(FALSE), not null
 #  note                    :text

--- a/spec/fixtures/libraries.yml
+++ b/spec/fixtures/libraries.yml
@@ -91,8 +91,8 @@ library_00004:
 #  users_count           :integer          default(0), not null
 #  position              :integer
 #  country_id            :integer
-#  created_at            :datetime
-#  updated_at            :datetime
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
 #  opening_hour          :text
 #  isil                  :string
 #  latitude              :float

--- a/spec/fixtures/library_groups.yml
+++ b/spec/fixtures/library_groups.yml
@@ -26,8 +26,8 @@ one:
 #  note                          :text
 #  country_id                    :integer
 #  position                      :integer
-#  created_at                    :datetime
-#  updated_at                    :datetime
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
 #  admin_networks                :text
 #  allow_bookmark_external_url   :boolean          default(FALSE), not null
 #  url                           :string           default("http://localhost:3000/")

--- a/spec/fixtures/licenses.yml
+++ b/spec/fixtures/licenses.yml
@@ -23,6 +23,6 @@ two:
 #  display_name :string
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/fixtures/manifestation_checkout_stats.yml
+++ b/spec/fixtures/manifestation_checkout_stats.yml
@@ -22,8 +22,8 @@ two:
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  started_at   :datetime
 #  completed_at :datetime
 #  user_id      :integer

--- a/spec/fixtures/manifestation_relationship_types.yml
+++ b/spec/fixtures/manifestation_relationship_types.yml
@@ -23,6 +23,6 @@ two:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/fixtures/manifestation_relationships.yml
+++ b/spec/fixtures/manifestation_relationships.yml
@@ -23,7 +23,7 @@ serial:
 #  parent_id                          :integer
 #  child_id                           :integer
 #  manifestation_relationship_type_id :integer
-#  created_at                         :datetime
-#  updated_at                         :datetime
+#  created_at                         :datetime         not null
+#  updated_at                         :datetime         not null
 #  position                           :integer
 #

--- a/spec/fixtures/manifestation_reserve_stats.yml
+++ b/spec/fixtures/manifestation_reserve_stats.yml
@@ -22,8 +22,8 @@ two:
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  started_at   :datetime
 #  completed_at :datetime
 #  user_id      :integer

--- a/spec/fixtures/manifestations.yml
+++ b/spec/fixtures/manifestations.yml
@@ -1847,8 +1847,8 @@ manifestation_00218:
 #  manifestation_identifier        :string
 #  date_of_publication             :datetime
 #  date_copyrighted                :datetime
-#  created_at                      :datetime
-#  updated_at                      :datetime
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
 #  access_address                  :string
 #  language_id                     :integer          default(1), not null
 #  carrier_type_id                 :integer          default(1), not null

--- a/spec/fixtures/medium_of_performances.yml
+++ b/spec/fixtures/medium_of_performances.yml
@@ -23,6 +23,6 @@ two:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/fixtures/news_feeds.yml
+++ b/spec/fixtures/news_feeds.yml
@@ -20,6 +20,6 @@ news_feed_00002:
 #  url              :string
 #  body             :text
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/fixtures/news_posts.yml
+++ b/spec/fixtures/news_posts.yml
@@ -26,7 +26,7 @@ news_post_00002:
 #  note             :text
 #  position         :integer
 #  draft            :boolean          default(FALSE), not null
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #  url              :string
 #

--- a/spec/fixtures/nii_types.yml
+++ b/spec/fixtures/nii_types.yml
@@ -86,6 +86,6 @@ nii_type_00013:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/fixtures/owns.yml
+++ b/spec/fixtures/owns.yml
@@ -20,6 +20,6 @@ own_00002:
 #  agent_id   :integer          not null
 #  item_id    :integer          not null
 #  position   :integer
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/spec/fixtures/picture_files.yml
+++ b/spec/fixtures/picture_files.yml
@@ -49,8 +49,8 @@ picture_file_00004:
 #  picture_attachable_type :string
 #  title                   :text
 #  position                :integer
-#  created_at              :datetime
-#  updated_at              :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #  picture_file_name       :string
 #  picture_content_type    :string
 #  picture_file_size       :integer

--- a/spec/fixtures/produce_types.yml
+++ b/spec/fixtures/produce_types.yml
@@ -25,6 +25,6 @@ seller:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/fixtures/produces.yml
+++ b/spec/fixtures/produces.yml
@@ -143,7 +143,7 @@ produce_00202:
 #  agent_id         :integer          not null
 #  manifestation_id :integer          not null
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #  produce_type_id  :integer
 #

--- a/spec/fixtures/profiles.yml
+++ b/spec/fixtures/profiles.yml
@@ -97,8 +97,8 @@ profile_user4:
 #  note                     :text
 #  keyword_list             :text
 #  required_role_id         :integer
-#  created_at               :datetime
-#  updated_at               :datetime
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
 #  checkout_icalendar_token :string
 #  save_checkout_history    :boolean          default(FALSE), not null
 #  expired_at               :datetime

--- a/spec/fixtures/realize_types.yml
+++ b/spec/fixtures/realize_types.yml
@@ -33,6 +33,6 @@ illustrator:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/fixtures/realizes.yml
+++ b/spec/fixtures/realizes.yml
@@ -80,7 +80,7 @@ realize_00010:
 #  agent_id        :integer          not null
 #  expression_id   :integer          not null
 #  position        :integer
-#  created_at      :datetime
-#  updated_at      :datetime
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
 #  realize_type_id :integer
 #

--- a/spec/fixtures/request_status_types.yml
+++ b/spec/fixtures/request_status_types.yml
@@ -57,7 +57,7 @@ request_status_type_00006:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #
 

--- a/spec/fixtures/request_types.yml
+++ b/spec/fixtures/request_types.yml
@@ -49,7 +49,7 @@ request_type_00004:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #
 

--- a/spec/fixtures/reserve_stat_has_manifestations.yml
+++ b/spec/fixtures/reserve_stat_has_manifestations.yml
@@ -18,6 +18,6 @@ two:
 #  manifestation_reserve_stat_id :integer          not null
 #  manifestation_id              :integer          not null
 #  reserves_count                :integer
-#  created_at                    :datetime
-#  updated_at                    :datetime
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
 #

--- a/spec/fixtures/reserve_stat_has_users.yml
+++ b/spec/fixtures/reserve_stat_has_users.yml
@@ -18,6 +18,6 @@ two:
 #  user_reserve_stat_id :integer          not null
 #  user_id              :integer          not null
 #  reserves_count       :integer
-#  created_at           :datetime
-#  updated_at           :datetime
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
 #

--- a/spec/fixtures/reserve_transitions.yml
+++ b/spec/fixtures/reserve_transitions.yml
@@ -98,7 +98,7 @@ reserve_transition_00015:
 #  metadata    :text             default({})
 #  sort_key    :integer
 #  reserve_id  :integer
-#  created_at  :datetime
-#  updated_at  :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
 #  most_recent :boolean          not null
 #

--- a/spec/fixtures/reserves.yml
+++ b/spec/fixtures/reserves.yml
@@ -149,8 +149,8 @@ reserve_00015:
 #  item_id                      :integer
 #  request_status_type_id       :integer          not null
 #  checked_out_at               :datetime
-#  created_at                   :datetime
-#  updated_at                   :datetime
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
 #  canceled_at                  :datetime
 #  expired_at                   :datetime
 #  expiration_notice_to_patron  :boolean          default(FALSE)

--- a/spec/fixtures/resource_export_files.yml
+++ b/spec/fixtures/resource_export_files.yml
@@ -21,6 +21,6 @@ resource_export_file_00003:
 #  resource_export_file_size    :bigint
 #  resource_export_updated_at   :datetime
 #  executed_at                  :datetime
-#  created_at                   :datetime
-#  updated_at                   :datetime
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
 #

--- a/spec/fixtures/resource_import_files.yml
+++ b/spec/fixtures/resource_import_files.yml
@@ -35,8 +35,8 @@ resource_import_file_00003:
 #  resource_import_content_type :string
 #  resource_import_file_size    :integer
 #  resource_import_updated_at   :datetime
-#  created_at                   :datetime
-#  updated_at                   :datetime
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
 #  edit_mode                    :string
 #  resource_import_fingerprint  :string
 #  error_message                :text

--- a/spec/fixtures/resource_import_results.yml
+++ b/spec/fixtures/resource_import_results.yml
@@ -23,7 +23,7 @@ two:
 #  manifestation_id        :integer
 #  item_id                 :integer
 #  body                    :text
-#  created_at              :datetime
-#  updated_at              :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #  error_message           :text
 #

--- a/spec/fixtures/roles.yml
+++ b/spec/fixtures/roles.yml
@@ -28,8 +28,8 @@ role_00004:
 #  name         :string           not null
 #  display_name :string
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  score        :integer          default(0), not null
 #  position     :integer
 #

--- a/spec/fixtures/search_engines.yml
+++ b/spec/fixtures/search_engines.yml
@@ -35,6 +35,6 @@ search_engine_00002:
 #  additional_param :text
 #  note             :text
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/fixtures/series_statement_merge_lists.yml
+++ b/spec/fixtures/series_statement_merge_lists.yml
@@ -21,6 +21,6 @@ series_statement_merge_list_00003:
 #
 #  id         :integer          not null, primary key
 #  title      :string
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/spec/fixtures/series_statement_merges.yml
+++ b/spec/fixtures/series_statement_merges.yml
@@ -25,6 +25,6 @@ series_statement_merge_00003:
 #  id                             :integer          not null, primary key
 #  series_statement_id            :integer          not null
 #  series_statement_merge_list_id :integer          not null
-#  created_at                     :datetime
-#  updated_at                     :datetime
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
 #

--- a/spec/fixtures/series_statements.yml
+++ b/spec/fixtures/series_statements.yml
@@ -39,8 +39,8 @@ five:
 #  title_subseries                    :text
 #  numbering_subseries                :text
 #  position                           :integer
-#  created_at                         :datetime
-#  updated_at                         :datetime
+#  created_at                         :datetime         not null
+#  updated_at                         :datetime         not null
 #  title_transcription                :text
 #  title_alternative                  :text
 #  series_statement_identifier        :string

--- a/spec/fixtures/shelves.yml
+++ b/spec/fixtures/shelves.yml
@@ -39,8 +39,8 @@ shelf_00004:
 #  library_id   :integer          not null
 #  items_count  :integer          default(0), not null
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  closed       :boolean          default(FALSE), not null
 #
 

--- a/spec/fixtures/subject_heading_types.yml
+++ b/spec/fixtures/subject_heading_types.yml
@@ -33,7 +33,7 @@ subject_heading_type_00003:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #
 

--- a/spec/fixtures/subject_types.yml
+++ b/spec/fixtures/subject_types.yml
@@ -36,6 +36,6 @@ subject_type_00004:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/fixtures/subjects.yml
+++ b/spec/fixtures/subjects.yml
@@ -70,8 +70,8 @@ subject_00005:
 #  note                    :text
 #  required_role_id        :integer          default(1), not null
 #  lock_version            :integer          default(0), not null
-#  created_at              :datetime
-#  updated_at              :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #  url                     :string
 #  manifestation_id        :integer
 #  subject_heading_type_id :integer

--- a/spec/fixtures/subscribes.yml
+++ b/spec/fixtures/subscribes.yml
@@ -39,6 +39,6 @@ subscription_00005:
 #  work_id         :integer          not null
 #  start_at        :datetime         not null
 #  end_at          :datetime         not null
-#  created_at      :datetime
-#  updated_at      :datetime
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
 #

--- a/spec/fixtures/subscriptions.yml
+++ b/spec/fixtures/subscriptions.yml
@@ -20,6 +20,6 @@ subscription_00002:
 #  user_id          :integer
 #  order_list_id    :integer
 #  subscribes_count :integer          default(0), not null
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/fixtures/use_restrictions.yml
+++ b/spec/fixtures/use_restrictions.yml
@@ -87,6 +87,6 @@ use_restriction_00013:
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/fixtures/user_checkout_stats.yml
+++ b/spec/fixtures/user_checkout_stats.yml
@@ -22,8 +22,8 @@ two:
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  started_at   :datetime
 #  completed_at :datetime
 #  user_id      :integer

--- a/spec/fixtures/user_export_files.yml
+++ b/spec/fixtures/user_export_files.yml
@@ -21,6 +21,6 @@ user_export_file_00003:
 #  user_export_file_size    :bigint
 #  user_export_updated_at   :datetime
 #  executed_at              :datetime
-#  created_at               :datetime
-#  updated_at               :datetime
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
 #

--- a/spec/fixtures/user_group_has_checkout_types.yml
+++ b/spec/fixtures/user_group_has_checkout_types.yml
@@ -104,7 +104,7 @@ user_group_has_checkout_type_00008:
 #  fixed_due_date                  :datetime
 #  note                            :text
 #  position                        :integer
-#  created_at                      :datetime
-#  updated_at                      :datetime
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
 #  current_checkout_count          :integer
 #

--- a/spec/fixtures/user_groups.yml
+++ b/spec/fixtures/user_groups.yml
@@ -39,8 +39,8 @@ user_group_00003:
 #  display_name                     :text
 #  note                             :text
 #  position                         :integer
-#  created_at                       :datetime
-#  updated_at                       :datetime
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
 #  valid_period_for_new_user        :integer          default(0), not null
 #  expired_at                       :datetime
 #  number_of_day_to_notify_overdue  :integer          default(0), not null

--- a/spec/fixtures/user_has_roles.yml
+++ b/spec/fixtures/user_has_roles.yml
@@ -35,7 +35,7 @@ user4:
 #  id         :integer          not null, primary key
 #  user_id    :integer          not null
 #  role_id    :integer          not null
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 

--- a/spec/fixtures/user_import_files.yml
+++ b/spec/fixtures/user_import_files.yml
@@ -41,8 +41,8 @@ two:
 #  user_import_fingerprint  :string
 #  edit_mode                :string
 #  error_message            :text
-#  created_at               :datetime
-#  updated_at               :datetime
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
 #  user_encoding            :string
 #  default_library_id       :integer
 #  default_user_group_id    :integer

--- a/spec/fixtures/user_import_results.yml
+++ b/spec/fixtures/user_import_results.yml
@@ -20,7 +20,7 @@ two:
 #  user_import_file_id :integer
 #  user_id             :integer
 #  body                :text
-#  created_at          :datetime
-#  updated_at          :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #  error_message       :text
 #

--- a/spec/fixtures/user_reserve_stats.yml
+++ b/spec/fixtures/user_reserve_stats.yml
@@ -22,8 +22,8 @@ two:
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  started_at   :datetime
 #  completed_at :datetime
 #  user_id      :integer

--- a/spec/models/accept_spec.rb
+++ b/spec/models/accept_spec.rb
@@ -21,6 +21,6 @@ end
 #  basket_id    :integer
 #  item_id      :integer
 #  librarian_id :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/models/agent_import_file_spec.rb
+++ b/spec/models/agent_import_file_spec.rb
@@ -99,8 +99,8 @@ end
 #  agent_import_content_type :string
 #  agent_import_file_size    :integer
 #  agent_import_updated_at   :datetime
-#  created_at                :datetime
-#  updated_at                :datetime
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
 #  agent_import_fingerprint  :string
 #  error_message             :text
 #  edit_mode                 :string

--- a/spec/models/agent_import_result_spec.rb
+++ b/spec/models/agent_import_result_spec.rb
@@ -13,6 +13,6 @@ end
 #  agent_import_file_id :integer
 #  agent_id             :integer
 #  body                 :text
-#  created_at           :datetime
-#  updated_at           :datetime
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
 #

--- a/spec/models/agent_merge_list_spec.rb
+++ b/spec/models/agent_merge_list_spec.rb
@@ -11,6 +11,6 @@ end
 #
 #  id         :integer          not null, primary key
 #  title      :string
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/spec/models/agent_merge_spec.rb
+++ b/spec/models/agent_merge_spec.rb
@@ -12,6 +12,6 @@ end
 #  id                  :integer          not null, primary key
 #  agent_id            :integer          not null
 #  agent_merge_list_id :integer          not null
-#  created_at          :datetime
-#  updated_at          :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #

--- a/spec/models/agent_relationship_spec.rb
+++ b/spec/models/agent_relationship_spec.rb
@@ -13,7 +13,7 @@ end
 #  parent_id                  :integer
 #  child_id                   :integer
 #  agent_relationship_type_id :integer
-#  created_at                 :datetime
-#  updated_at                 :datetime
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
 #  position                   :integer
 #

--- a/spec/models/agent_relationship_type_spec.rb
+++ b/spec/models/agent_relationship_type_spec.rb
@@ -14,6 +14,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -85,8 +85,8 @@ end
 #  full_name                           :string
 #  full_name_transcription             :text
 #  full_name_alternative               :text
-#  created_at                          :datetime
-#  updated_at                          :datetime
+#  created_at                          :datetime         not null
+#  updated_at                          :datetime         not null
 #  zip_code_1                          :string
 #  zip_code_2                          :string
 #  address_1                           :text

--- a/spec/models/agent_type_spec.rb
+++ b/spec/models/agent_type_spec.rb
@@ -14,6 +14,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/models/basket_spec.rb
+++ b/spec/models/basket_spec.rb
@@ -60,6 +60,6 @@ end
 #  user_id      :integer
 #  note         :text
 #  lock_version :integer          default(0), not null
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/models/bookstore_spec.rb
+++ b/spec/models/bookstore_spec.rb
@@ -18,6 +18,6 @@ end
 #  fax_number       :string
 #  url              :string
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/models/budget_type_spec.rb
+++ b/spec/models/budget_type_spec.rb
@@ -15,6 +15,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/models/carrier_type_has_checkout_type_spec.rb
+++ b/spec/models/carrier_type_has_checkout_type_spec.rb
@@ -14,6 +14,6 @@ end
 #  checkout_type_id :integer          not null
 #  note             :text
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/models/carrier_type_spec.rb
+++ b/spec/models/carrier_type_spec.rb
@@ -18,8 +18,8 @@ end
 #  display_name            :text
 #  note                    :text
 #  position                :integer
-#  created_at              :datetime
-#  updated_at              :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #  attachment_file_name    :string
 #  attachment_content_type :string
 #  attachment_file_size    :bigint

--- a/spec/models/checked_item_spec.rb
+++ b/spec/models/checked_item_spec.rb
@@ -38,7 +38,7 @@ end
 #  basket_id    :integer          not null
 #  librarian_id :integer
 #  due_date     :datetime         not null
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  user_id      :integer
 #

--- a/spec/models/checkin_spec.rb
+++ b/spec/models/checkin_spec.rb
@@ -43,7 +43,7 @@ end
 #  item_id      :integer          not null
 #  librarian_id :integer
 #  basket_id    :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  lock_version :integer          default(0), not null
 #

--- a/spec/models/checkout_spec.rb
+++ b/spec/models/checkout_spec.rb
@@ -70,8 +70,8 @@ end
 #  due_date               :datetime
 #  checkout_renewal_count :integer          default(0), not null
 #  lock_version           :integer          default(0), not null
-#  created_at             :datetime
-#  updated_at             :datetime
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
 #  shelf_id               :integer
 #  library_id             :integer
 #

--- a/spec/models/checkout_stat_has_manifestation_spec.rb
+++ b/spec/models/checkout_stat_has_manifestation_spec.rb
@@ -13,6 +13,6 @@ end
 #  manifestation_checkout_stat_id :integer          not null
 #  manifestation_id               :integer          not null
 #  checkouts_count                :integer
-#  created_at                     :datetime
-#  updated_at                     :datetime
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
 #

--- a/spec/models/checkout_stat_has_user_spec.rb
+++ b/spec/models/checkout_stat_has_user_spec.rb
@@ -13,6 +13,6 @@ end
 #  user_checkout_stat_id :integer          not null
 #  user_id               :integer          not null
 #  checkouts_count       :integer          default(0), not null
-#  created_at            :datetime
-#  updated_at            :datetime
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
 #

--- a/spec/models/checkout_type_spec.rb
+++ b/spec/models/checkout_type_spec.rb
@@ -14,6 +14,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/models/circulation_status_spec.rb
+++ b/spec/models/circulation_status_spec.rb
@@ -14,6 +14,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/models/content_type_spec.rb
+++ b/spec/models/content_type_spec.rb
@@ -14,6 +14,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/models/create_spec.rb
+++ b/spec/models/create_spec.rb
@@ -13,7 +13,7 @@ end
 #  agent_id       :integer          not null
 #  work_id        :integer          not null
 #  position       :integer
-#  created_at     :datetime
-#  updated_at     :datetime
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
 #  create_type_id :integer
 #

--- a/spec/models/create_type_spec.rb
+++ b/spec/models/create_type_spec.rb
@@ -15,6 +15,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/models/donate_spec.rb
+++ b/spec/models/donate_spec.rb
@@ -12,6 +12,6 @@ end
 #  id         :integer          not null, primary key
 #  agent_id   :integer          not null
 #  item_id    :integer          not null
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/spec/models/form_of_work_spec.rb
+++ b/spec/models/form_of_work_spec.rb
@@ -14,6 +14,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/models/frequency_spec.rb
+++ b/spec/models/frequency_spec.rb
@@ -17,6 +17,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/models/identifier_spec.rb
+++ b/spec/models/identifier_spec.rb
@@ -15,6 +15,6 @@ end
 #  manifestation_id   :integer
 #  primary            :boolean
 #  position           :integer
-#  created_at         :datetime
-#  updated_at         :datetime
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #

--- a/spec/models/identifier_type_spec.rb
+++ b/spec/models/identifier_type_spec.rb
@@ -14,6 +14,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/models/import_request_spec.rb
+++ b/spec/models/import_request_spec.rb
@@ -21,6 +21,6 @@ end
 #  isbn             :string
 #  manifestation_id :integer
 #  user_id          :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -45,8 +45,8 @@ end
 #  id                      :integer          not null, primary key
 #  call_number             :string
 #  item_identifier         :string
-#  created_at              :datetime
-#  updated_at              :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #  shelf_id                :integer          default(1), not null
 #  include_supplements     :boolean          default(FALSE), not null
 #  note                    :text

--- a/spec/models/library_group_spec.rb
+++ b/spec/models/library_group_spec.rb
@@ -36,8 +36,8 @@ end
 #  note                          :text
 #  country_id                    :integer
 #  position                      :integer
-#  created_at                    :datetime
-#  updated_at                    :datetime
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
 #  admin_networks                :text
 #  allow_bookmark_external_url   :boolean          default(FALSE), not null
 #  url                           :string           default("http://localhost:3000/")

--- a/spec/models/library_spec.rb
+++ b/spec/models/library_spec.rb
@@ -35,8 +35,8 @@ end
 #  users_count           :integer          default(0), not null
 #  position              :integer
 #  country_id            :integer
-#  created_at            :datetime
-#  updated_at            :datetime
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
 #  opening_hour          :text
 #  isil                  :string
 #  latitude              :float

--- a/spec/models/license_spec.rb
+++ b/spec/models/license_spec.rb
@@ -14,6 +14,6 @@ end
 #  display_name :string
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/models/manifestation_checkout_stat_spec.rb
+++ b/spec/models/manifestation_checkout_stat_spec.rb
@@ -23,8 +23,8 @@ end
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  started_at   :datetime
 #  completed_at :datetime
 #  user_id      :integer

--- a/spec/models/manifestation_relationship_spec.rb
+++ b/spec/models/manifestation_relationship_spec.rb
@@ -13,7 +13,7 @@ end
 #  parent_id                          :integer
 #  child_id                           :integer
 #  manifestation_relationship_type_id :integer
-#  created_at                         :datetime
-#  updated_at                         :datetime
+#  created_at                         :datetime         not null
+#  updated_at                         :datetime         not null
 #  position                           :integer
 #

--- a/spec/models/manifestation_relationship_type_spec.rb
+++ b/spec/models/manifestation_relationship_type_spec.rb
@@ -14,6 +14,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/models/manifestation_reserve_stat_spec.rb
+++ b/spec/models/manifestation_reserve_stat_spec.rb
@@ -23,8 +23,8 @@ end
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  started_at   :datetime
 #  completed_at :datetime
 #  user_id      :integer

--- a/spec/models/manifestation_spec.rb
+++ b/spec/models/manifestation_spec.rb
@@ -287,8 +287,8 @@ end
 #  manifestation_identifier        :string
 #  date_of_publication             :datetime
 #  date_copyrighted                :datetime
-#  created_at                      :datetime
-#  updated_at                      :datetime
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
 #  access_address                  :string
 #  language_id                     :integer          default(1), not null
 #  carrier_type_id                 :integer          default(1), not null

--- a/spec/models/medium_of_performance_spec.rb
+++ b/spec/models/medium_of_performance_spec.rb
@@ -14,6 +14,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/models/news_feed_spec.rb
+++ b/spec/models/news_feed_spec.rb
@@ -34,6 +34,6 @@ end
 #  url              :string
 #  body             :text
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/models/news_post_spec.rb
+++ b/spec/models/news_post_spec.rb
@@ -17,7 +17,7 @@ end
 #  note             :text
 #  position         :integer
 #  draft            :boolean          default(FALSE), not null
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #  url              :string
 #

--- a/spec/models/own_spec.rb
+++ b/spec/models/own_spec.rb
@@ -13,6 +13,6 @@ end
 #  agent_id   :integer          not null
 #  item_id    :integer          not null
 #  position   :integer
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/spec/models/picture_file_spec.rb
+++ b/spec/models/picture_file_spec.rb
@@ -20,8 +20,8 @@ end
 #  picture_attachable_type :string
 #  title                   :text
 #  position                :integer
-#  created_at              :datetime
-#  updated_at              :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #  picture_file_name       :string
 #  picture_content_type    :string
 #  picture_file_size       :integer

--- a/spec/models/produce_spec.rb
+++ b/spec/models/produce_spec.rb
@@ -13,7 +13,7 @@ end
 #  agent_id         :integer          not null
 #  manifestation_id :integer          not null
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #  produce_type_id  :integer
 #

--- a/spec/models/produce_type_spec.rb
+++ b/spec/models/produce_type_spec.rb
@@ -15,6 +15,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -65,8 +65,8 @@ end
 #  note                     :text
 #  keyword_list             :text
 #  required_role_id         :integer
-#  created_at               :datetime
-#  updated_at               :datetime
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
 #  checkout_icalendar_token :string
 #  save_checkout_history    :boolean          default(FALSE), not null
 #  expired_at               :datetime

--- a/spec/models/realize_spec.rb
+++ b/spec/models/realize_spec.rb
@@ -13,7 +13,7 @@ end
 #  agent_id        :integer          not null
 #  expression_id   :integer          not null
 #  position        :integer
-#  created_at      :datetime
-#  updated_at      :datetime
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
 #  realize_type_id :integer
 #

--- a/spec/models/realize_type_spec.rb
+++ b/spec/models/realize_type_spec.rb
@@ -15,6 +15,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/models/request_status_type_spec.rb
+++ b/spec/models/request_status_type_spec.rb
@@ -14,6 +14,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/models/request_type_spec.rb
+++ b/spec/models/request_type_spec.rb
@@ -14,6 +14,6 @@ end
 #  display_name :text
 #  note         :text
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #

--- a/spec/models/reserve_spec.rb
+++ b/spec/models/reserve_spec.rb
@@ -138,8 +138,8 @@ end
 #  item_id                      :integer
 #  request_status_type_id       :integer          not null
 #  checked_out_at               :datetime
-#  created_at                   :datetime
-#  updated_at                   :datetime
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
 #  canceled_at                  :datetime
 #  expired_at                   :datetime
 #  expiration_notice_to_patron  :boolean          default(FALSE)

--- a/spec/models/reserve_stat_has_manifestation_spec.rb
+++ b/spec/models/reserve_stat_has_manifestation_spec.rb
@@ -13,6 +13,6 @@ end
 #  manifestation_reserve_stat_id :integer          not null
 #  manifestation_id              :integer          not null
 #  reserves_count                :integer
-#  created_at                    :datetime
-#  updated_at                    :datetime
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
 #

--- a/spec/models/reserve_stat_has_user_spec.rb
+++ b/spec/models/reserve_stat_has_user_spec.rb
@@ -13,6 +13,6 @@ end
 #  user_reserve_stat_id :integer          not null
 #  user_id              :integer          not null
 #  reserves_count       :integer
-#  created_at           :datetime
-#  updated_at           :datetime
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
 #

--- a/spec/models/resource_export_file_spec.rb
+++ b/spec/models/resource_export_file_spec.rb
@@ -35,6 +35,6 @@ end
 #  resource_export_file_size    :bigint
 #  resource_export_updated_at   :datetime
 #  executed_at                  :datetime
-#  created_at                   :datetime
-#  updated_at                   :datetime
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
 #

--- a/spec/models/resource_import_file_spec.rb
+++ b/spec/models/resource_import_file_spec.rb
@@ -483,8 +483,8 @@ end
 #  resource_import_content_type :string
 #  resource_import_file_size    :integer
 #  resource_import_updated_at   :datetime
-#  created_at                   :datetime
-#  updated_at                   :datetime
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
 #  edit_mode                    :string
 #  resource_import_fingerprint  :string
 #  error_message                :text

--- a/spec/models/resource_import_result_spec.rb
+++ b/spec/models/resource_import_result_spec.rb
@@ -14,7 +14,7 @@ end
 #  manifestation_id        :integer
 #  item_id                 :integer
 #  body                    :text
-#  created_at              :datetime
-#  updated_at              :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #  error_message           :text
 #

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -32,8 +32,8 @@ end
 #  name         :string           not null
 #  display_name :string
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  score        :integer          default(0), not null
 #  position     :integer
 #

--- a/spec/models/search_engine_spec.rb
+++ b/spec/models/search_engine_spec.rb
@@ -22,6 +22,6 @@ end
 #  additional_param :text
 #  note             :text
 #  position         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/models/series_statement_merge_list_spec.rb
+++ b/spec/models/series_statement_merge_list_spec.rb
@@ -14,6 +14,6 @@ end
 #
 #  id         :integer          not null, primary key
 #  title      :string
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/spec/models/series_statement_merge_spec.rb
+++ b/spec/models/series_statement_merge_spec.rb
@@ -11,6 +11,6 @@ end
 #  id                             :integer          not null, primary key
 #  series_statement_id            :integer          not null
 #  series_statement_merge_list_id :integer          not null
-#  created_at                     :datetime
-#  updated_at                     :datetime
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
 #

--- a/spec/models/series_statement_spec.rb
+++ b/spec/models/series_statement_spec.rb
@@ -19,8 +19,8 @@ end
 #  title_subseries                    :text
 #  numbering_subseries                :text
 #  position                           :integer
-#  created_at                         :datetime
-#  updated_at                         :datetime
+#  created_at                         :datetime         not null
+#  updated_at                         :datetime         not null
 #  title_transcription                :text
 #  title_alternative                  :text
 #  series_statement_identifier        :string

--- a/spec/models/shelf_spec.rb
+++ b/spec/models/shelf_spec.rb
@@ -20,7 +20,7 @@ end
 #  library_id   :integer          not null
 #  items_count  :integer          default(0), not null
 #  position     :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  closed       :boolean          default(FALSE), not null
 #

--- a/spec/models/subscribe_spec.rb
+++ b/spec/models/subscribe_spec.rb
@@ -14,6 +14,6 @@ end
 #  work_id         :integer          not null
 #  start_at        :datetime         not null
 #  end_at          :datetime         not null
-#  created_at      :datetime
-#  updated_at      :datetime
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
 #

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -18,6 +18,6 @@ end
 #  user_id          :integer
 #  order_list_id    :integer
 #  subscribes_count :integer          default(0), not null
-#  created_at       :datetime
-#  updated_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #

--- a/spec/models/user_checkout_stat_spec.rb
+++ b/spec/models/user_checkout_stat_spec.rb
@@ -23,8 +23,8 @@ end
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  started_at   :datetime
 #  completed_at :datetime
 #  user_id      :integer

--- a/spec/models/user_export_file_spec.rb
+++ b/spec/models/user_export_file_spec.rb
@@ -24,6 +24,6 @@ end
 #  user_export_file_size    :bigint
 #  user_export_updated_at   :datetime
 #  executed_at              :datetime
-#  created_at               :datetime
-#  updated_at               :datetime
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
 #

--- a/spec/models/user_group_has_checkout_type_spec.rb
+++ b/spec/models/user_group_has_checkout_type_spec.rb
@@ -24,7 +24,7 @@ end
 #  fixed_due_date                  :datetime
 #  note                            :text
 #  position                        :integer
-#  created_at                      :datetime
-#  updated_at                      :datetime
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
 #  current_checkout_count          :integer
 #

--- a/spec/models/user_group_spec.rb
+++ b/spec/models/user_group_spec.rb
@@ -25,8 +25,8 @@ end
 #  display_name                     :text
 #  note                             :text
 #  position                         :integer
-#  created_at                       :datetime
-#  updated_at                       :datetime
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
 #  valid_period_for_new_user        :integer          default(0), not null
 #  expired_at                       :datetime
 #  number_of_day_to_notify_overdue  :integer          default(0), not null

--- a/spec/models/user_has_role_spec.rb
+++ b/spec/models/user_has_role_spec.rb
@@ -12,6 +12,6 @@ end
 #  id         :integer          not null, primary key
 #  user_id    :integer          not null
 #  role_id    :integer          not null
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/spec/models/user_import_file_spec.rb
+++ b/spec/models/user_import_file_spec.rb
@@ -262,8 +262,8 @@ end
 #  user_import_fingerprint  :string
 #  edit_mode                :string
 #  error_message            :text
-#  created_at               :datetime
-#  updated_at               :datetime
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
 #  user_encoding            :string
 #  default_library_id       :integer
 #  default_user_group_id    :integer

--- a/spec/models/user_import_result_spec.rb
+++ b/spec/models/user_import_result_spec.rb
@@ -13,7 +13,7 @@ end
 #  user_import_file_id :integer
 #  user_id             :integer
 #  body                :text
-#  created_at          :datetime
-#  updated_at          :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #  error_message       :text
 #

--- a/spec/models/user_reserve_stat_spec.rb
+++ b/spec/models/user_reserve_stat_spec.rb
@@ -23,8 +23,8 @@ end
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text
-#  created_at   :datetime
-#  updated_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #  started_at   :datetime
 #  completed_at :datetime
 #  user_id      :integer


### PR DESCRIPTION
古いバージョンのRailsで作成したテーブルには、created_atとupdated_atカラムにnot null制約がついていなかった。このPRでそれらにnot null制約を追加している。