### PR TITLE
Nodejsのバージョンを16.xに固定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG UID=1000
 ARG GID=1000
 
 RUN groupadd --gid ${GID} enju && useradd -m --uid ${UID} --gid ${GID} enju
-RUN apt-get update -qq && curl -sL https://deb.nodesource.com/setup_lts.x | bash - && \
+RUN apt-get update -qq && curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
 apt-get install -y nodejs postgresql-client imagemagick mupdf-tools ffmpeg && npm install -g yarn && yarn install
 RUN mkdir /enju && chown -R enju:enju /enju
 USER enju

--- a/lib/enju_leaf/version.rb
+++ b/lib/enju_leaf/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EnjuLeaf
-  VERSION = "1.4.0".freeze
+  VERSION = "1.4.1".freeze
 end


### PR DESCRIPTION
1.4.0で `rake assets:precompile` コマンドを実行する際、以下のエラーが発生した。

```
Error: error:0308010C:digital envelope routines::unsupported
```

これはNode.jsのバージョンが新しすぎるためとのこと。
https://zenn.dev/pontagon333/articles/26c89cbc14e81f

EnjuではNode.jsの18.x（LTS版）を指定していたが、このPRで16.xにバージョンを戻している。