### PR TITLE
資料と人物の関係のバリデーションとインデックスを更新

### DIFF
--- a/app/models/agent_merge_list.rb
+++ b/app/models/agent_merge_list.rb
@@ -7,10 +7,10 @@ class AgentMergeList < ApplicationRecord
 
   def merge_agents(selected_agent)
     agents.each do |agent|
-      Create.where(agent_id: selected_agent.id).update_all(agent_id: agent.id)
-      Produce.where(agent_id: selected_agent.id).update_all(agent_id: agent.id)
-      Own.where(agent_id: selected_agent.id).update_all(agent_id: agent.id)
-      Donate.where(agent_id: selected_agent.id).update_all(agent_id: agent.id)
+      Create.where(agent_id: selected_agent.id).update(agent_id: agent.id)
+      Produce.where(agent_id: selected_agent.id).update(agent_id: agent.id)
+      Own.where(agent_id: selected_agent.id).update(agent_id: agent.id)
+      Donate.where(agent_id: selected_agent.id).update(agent_id: agent.id)
       agent.destroy unless agent == selected_agent
     end
   end

--- a/app/models/create.rb
+++ b/app/models/create.rb
@@ -3,7 +3,7 @@ class Create < ApplicationRecord
   belongs_to :work, class_name: 'Manifestation', touch: true
   belongs_to :create_type, optional: true
 
-  validates :work_id, uniqueness: { scope: :agent_id }
+  validates :agent_id, uniqueness: { scope: :work_id }
   after_destroy :reindex
   after_save :reindex
 

--- a/app/models/own.rb
+++ b/app/models/own.rb
@@ -2,7 +2,7 @@ class Own < ApplicationRecord
   belongs_to :agent
   belongs_to :item
 
-  validates :item_id, uniqueness: { scope: :agent_id }
+  validates :agent_id, uniqueness: { scope: :item_id }
   after_destroy :reindex
   after_save :reindex
 

--- a/app/models/produce.rb
+++ b/app/models/produce.rb
@@ -4,7 +4,7 @@ class Produce < ApplicationRecord
   belongs_to :produce_type, optional: true
   delegate :original_title, to: :manifestation, prefix: true
 
-  validates :manifestation_id, uniqueness: { scope: :agent_id }
+  validates :agent_id, uniqueness: { scope: :manifestation_id }
   after_destroy :reindex
   after_save :reindex
 

--- a/app/models/realize.rb
+++ b/app/models/realize.rb
@@ -3,7 +3,7 @@ class Realize < ApplicationRecord
   belongs_to :expression, class_name: 'Manifestation', touch: true
   belongs_to :realize_type, optional: true
 
-  validates :expression_id, uniqueness: { scope: :agent_id }
+  validates :agent_id, uniqueness: { scope: :expression_id }
   after_destroy :reindex
   after_save :reindex
 

--- a/db/migrate/20221112064827_add_index_to_creates_on_work_id_and_agent_id.rb
+++ b/db/migrate/20221112064827_add_index_to_creates_on_work_id_and_agent_id.rb
@@ -1,0 +1,6 @@
+class AddIndexToCreatesOnWorkIdAndAgentId < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :creates, :work_id
+    add_index :creates, [:work_id, :agent_id], unique: true
+  end
+end

--- a/db/migrate/20221112064837_add_index_to_realizes_on_expression_id_and_agent_id.rb
+++ b/db/migrate/20221112064837_add_index_to_realizes_on_expression_id_and_agent_id.rb
@@ -1,0 +1,6 @@
+class AddIndexToRealizesOnExpressionIdAndAgentId < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :realizes, :expression_id
+    add_index :realizes, [:expression_id, :agent_id], unique: true
+  end
+end

--- a/db/migrate/20221112064850_add_index_to_produces_on_manifestation_id_and_agent_id.rb
+++ b/db/migrate/20221112064850_add_index_to_produces_on_manifestation_id_and_agent_id.rb
@@ -1,0 +1,6 @@
+class AddIndexToProducesOnManifestationIdAndAgentId < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :produces, :manifestation_id
+    add_index :produces, [:manifestation_id, :agent_id], unique: true
+  end
+end

--- a/db/migrate/20221112065100_add_index_to_owns_on_item_id_and_agent_id.rb
+++ b/db/migrate/20221112065100_add_index_to_owns_on_item_id_and_agent_id.rb
@@ -1,0 +1,6 @@
+class AddIndexToOwnsOnItemIdAndAgentId < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :owns, :item_id
+    add_index :owns, [:item_id, :agent_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_12_015501) do
+ActiveRecord::Schema.define(version: 2022_11_12_065100) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -433,7 +433,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_015501) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "create_type_id"
     t.index ["agent_id"], name: "index_creates_on_agent_id"
-    t.index ["work_id"], name: "index_creates_on_work_id"
+    t.index ["work_id", "agent_id"], name: "index_creates_on_work_id_and_agent_id", unique: true
   end
 
   create_table "demands", id: :serial, force: :cascade do |t|
@@ -1087,7 +1087,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_015501) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["agent_id"], name: "index_owns_on_agent_id"
-    t.index ["item_id"], name: "index_owns_on_item_id"
+    t.index ["item_id", "agent_id"], name: "index_owns_on_item_id_and_agent_id", unique: true
   end
 
   create_table "participates", id: :serial, force: :cascade do |t|
@@ -1147,7 +1147,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_015501) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "produce_type_id"
     t.index ["agent_id"], name: "index_produces_on_agent_id"
-    t.index ["manifestation_id"], name: "index_produces_on_manifestation_id"
+    t.index ["manifestation_id", "agent_id"], name: "index_produces_on_manifestation_id_and_agent_id", unique: true
   end
 
   create_table "profiles", id: :serial, force: :cascade do |t|
@@ -1192,7 +1192,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_015501) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "realize_type_id"
     t.index ["agent_id"], name: "index_realizes_on_agent_id"
-    t.index ["expression_id"], name: "index_realizes_on_expression_id"
+    t.index ["expression_id", "agent_id"], name: "index_realizes_on_expression_id_and_agent_id", unique: true
   end
 
   create_table "request_status_types", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
- たとえば、createsテーブルは資料と著者の関係を扱うテーブルで、work_idカラムとagent_idカラムが存在する
- ひとつの資料に同じ著者が複数紐づくことはないため、work_idカラムとagent_idカラムの組み合わせは一意になる。この組み合わせに対して、ユニークインデックスを追加する
- これにあわせて、一意性チェックのバリデーションの順序を、agent_id -> work_idからwork_id -> agent_idに変更する
- realizes, produces, ownsテーブルも同様