### PR TITLE
idカラムのデータ型をbigintに変更

### DIFF
--- a/app/models/accept.rb
+++ b/app/models/accept.rb
@@ -16,7 +16,7 @@ end
 #
 # Table name: accepts
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  basket_id    :integer
 #  item_id      :integer
 #  librarian_id :integer

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -287,7 +287,7 @@ end
 #
 # Table name: agents
 #
-#  id                                  :integer          not null, primary key
+#  id                                  :bigint           not null, primary key
 #  last_name                           :string
 #  middle_name                         :string
 #  first_name                          :string

--- a/app/models/agent_import_file.rb
+++ b/app/models/agent_import_file.rb
@@ -236,7 +236,7 @@ end
 #
 # Table name: agent_import_files
 #
-#  id                        :integer          not null, primary key
+#  id                        :bigint           not null, primary key
 #  parent_id                 :integer
 #  content_type              :string
 #  size                      :integer

--- a/app/models/agent_import_file_transition.rb
+++ b/app/models/agent_import_file_transition.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: agent_import_file_transitions
 #
-#  id                   :integer          not null, primary key
+#  id                   :bigint           not null, primary key
 #  to_state             :string
 #  metadata             :text             default({})
 #  sort_key             :integer

--- a/app/models/agent_import_result.rb
+++ b/app/models/agent_import_result.rb
@@ -11,7 +11,7 @@ end
 #
 # Table name: agent_import_results
 #
-#  id                   :integer          not null, primary key
+#  id                   :bigint           not null, primary key
 #  agent_import_file_id :integer
 #  agent_id             :integer
 #  body                 :text

--- a/app/models/agent_merge.rb
+++ b/app/models/agent_merge.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: agent_merges
 #
-#  id                  :integer          not null, primary key
+#  id                  :bigint           not null, primary key
 #  agent_id            :integer          not null
 #  agent_merge_list_id :integer          not null
 #  created_at          :datetime         not null

--- a/app/models/agent_merge_list.rb
+++ b/app/models/agent_merge_list.rb
@@ -20,7 +20,7 @@ end
 #
 # Table name: agent_merge_lists
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/agent_relationship.rb
+++ b/app/models/agent_relationship.rb
@@ -14,7 +14,7 @@ end
 #
 # Table name: agent_relationships
 #
-#  id                         :integer          not null, primary key
+#  id                         :bigint           not null, primary key
 #  parent_id                  :integer
 #  child_id                   :integer
 #  agent_relationship_type_id :integer

--- a/app/models/agent_relationship_type.rb
+++ b/app/models/agent_relationship_type.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: agent_relationship_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/app/models/agent_type.rb
+++ b/app/models/agent_type.rb
@@ -7,7 +7,7 @@ end
 #
 # Table name: agent_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/app/models/basket.rb
+++ b/app/models/basket.rb
@@ -30,7 +30,7 @@ end
 #
 # Table name: baskets
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  user_id      :integer
 #  note         :text
 #  lock_version :integer          default(0), not null

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -185,7 +185,7 @@ end
 #
 # Table name: bookmarks
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  user_id          :integer          not null
 #  manifestation_id :integer
 #  title            :text

--- a/app/models/bookmark_stat.rb
+++ b/app/models/bookmark_stat.rb
@@ -51,7 +51,7 @@ end
 #
 # Table name: bookmark_stats
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  start_date   :datetime
 #  end_date     :datetime
 #  started_at   :datetime

--- a/app/models/bookmark_stat_has_manifestation.rb
+++ b/app/models/bookmark_stat_has_manifestation.rb
@@ -11,7 +11,7 @@ end
 #
 # Table name: bookmark_stat_has_manifestations
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  bookmark_stat_id :integer          not null
 #  manifestation_id :integer          not null
 #  bookmarks_count  :integer

--- a/app/models/bookmark_stat_transition.rb
+++ b/app/models/bookmark_stat_transition.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: bookmark_stat_transitions
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  to_state         :string
 #  metadata         :text             default({})
 #  sort_key         :integer

--- a/app/models/bookstore.rb
+++ b/app/models/bookstore.rb
@@ -17,7 +17,7 @@ end
 #
 # Table name: bookstores
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  name             :text             not null
 #  zip_code         :string
 #  address          :text

--- a/app/models/budget_type.rb
+++ b/app/models/budget_type.rb
@@ -14,8 +14,8 @@ end
 #
 # Table name: budget_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/app/models/carrier_type.rb
+++ b/app/models/carrier_type.rb
@@ -41,7 +41,7 @@ end
 #
 # Table name: carrier_types
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  name                    :string           not null
 #  display_name            :text
 #  note                    :text

--- a/app/models/carrier_type_has_checkout_type.rb
+++ b/app/models/carrier_type_has_checkout_type.rb
@@ -14,7 +14,7 @@ end
 #
 # Table name: carrier_type_has_checkout_types
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  carrier_type_id  :integer          not null
 #  checkout_type_id :integer          not null
 #  note             :text

--- a/app/models/checked_item.rb
+++ b/app/models/checked_item.rb
@@ -122,7 +122,7 @@ end
 #
 # Table name: checked_items
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  item_id      :integer          not null
 #  basket_id    :integer          not null
 #  librarian_id :integer

--- a/app/models/checkin.rb
+++ b/app/models/checkin.rb
@@ -81,7 +81,7 @@ end
 #
 # Table name: checkins
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  item_id      :integer          not null
 #  librarian_id :integer
 #  basket_id    :integer

--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -190,7 +190,7 @@ end
 #
 # Table name: checkouts
 #
-#  id                     :integer          not null, primary key
+#  id                     :bigint           not null, primary key
 #  user_id                :integer
 #  item_id                :integer          not null
 #  checkin_id             :integer

--- a/app/models/checkout_stat_has_manifestation.rb
+++ b/app/models/checkout_stat_has_manifestation.rb
@@ -11,7 +11,7 @@ end
 #
 # Table name: checkout_stat_has_manifestations
 #
-#  id                             :integer          not null, primary key
+#  id                             :bigint           not null, primary key
 #  manifestation_checkout_stat_id :integer          not null
 #  manifestation_id               :integer          not null
 #  checkouts_count                :integer

--- a/app/models/checkout_stat_has_user.rb
+++ b/app/models/checkout_stat_has_user.rb
@@ -11,7 +11,7 @@ end
 #
 # Table name: checkout_stat_has_users
 #
-#  id                    :integer          not null, primary key
+#  id                    :bigint           not null, primary key
 #  user_checkout_stat_id :integer          not null
 #  user_id               :integer          not null
 #  checkouts_count       :integer          default(0), not null

--- a/app/models/checkout_type.rb
+++ b/app/models/checkout_type.rb
@@ -18,7 +18,7 @@ end
 #
 # Table name: checkout_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/app/models/circulation_status.rb
+++ b/app/models/circulation_status.rb
@@ -17,7 +17,7 @@ end
 #
 # Table name: circulation_statuses
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -16,7 +16,7 @@ end
 #
 # Table name: classifications
 #
-#  id                     :integer          not null, primary key
+#  id                     :bigint           not null, primary key
 #  parent_id              :integer
 #  category               :string           not null
 #  note                   :text

--- a/app/models/classification_type.rb
+++ b/app/models/classification_type.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: classification_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/app/models/color.rb
+++ b/app/models/color.rb
@@ -10,7 +10,7 @@ end
 #
 # Table name: colors
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  library_group_id :integer
 #  property         :string
 #  code             :string

--- a/app/models/content_type.rb
+++ b/app/models/content_type.rb
@@ -7,7 +7,7 @@ end
 #
 # Table name: content_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -36,7 +36,7 @@ end
 #
 # Table name: countries
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  alpha_2      :string

--- a/app/models/create.rb
+++ b/app/models/create.rb
@@ -19,7 +19,7 @@ end
 #
 # Table name: creates
 #
-#  id             :integer          not null, primary key
+#  id             :bigint           not null, primary key
 #  agent_id       :integer          not null
 #  work_id        :integer          not null
 #  position       :integer

--- a/app/models/create_type.rb
+++ b/app/models/create_type.rb
@@ -7,8 +7,8 @@ end
 #
 # Table name: create_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/app/models/demand.rb
+++ b/app/models/demand.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: demands
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  user_id    :integer
 #  item_id    :integer
 #  message_id :integer

--- a/app/models/donate.rb
+++ b/app/models/donate.rb
@@ -7,7 +7,7 @@ end
 #
 # Table name: donates
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  agent_id   :integer          not null
 #  item_id    :integer          not null
 #  created_at :datetime         not null

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -108,10 +108,10 @@ end
 #
 # Table name: events
 #
-#  id                :integer          not null, primary key
+#  id                :bigint           not null, primary key
 #  library_id        :integer          not null
 #  event_category_id :integer          not null
-#  name              :string
+#  name              :string           not null
 #  note              :text
 #  start_at          :datetime
 #  end_at            :datetime

--- a/app/models/event_category.rb
+++ b/app/models/event_category.rb
@@ -12,7 +12,7 @@ end
 #
 # Table name: event_categories
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/app/models/event_export_file.rb
+++ b/app/models/event_export_file.rb
@@ -54,7 +54,7 @@ end
 #
 # Table name: event_export_files
 #
-#  id                        :integer          not null, primary key
+#  id                        :bigint           not null, primary key
 #  user_id                   :integer
 #  event_export_file_name    :string
 #  event_export_content_type :string

--- a/app/models/event_export_file_transition.rb
+++ b/app/models/event_export_file_transition.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: event_export_file_transitions
 #
-#  id                   :integer          not null, primary key
+#  id                   :bigint           not null, primary key
 #  to_state             :string
 #  metadata             :text             default({})
 #  sort_key             :integer

--- a/app/models/event_import_file.rb
+++ b/app/models/event_import_file.rb
@@ -206,7 +206,7 @@ end
 #
 # Table name: event_import_files
 #
-#  id                        :integer          not null, primary key
+#  id                        :bigint           not null, primary key
 #  parent_id                 :integer
 #  content_type              :string
 #  size                      :integer

--- a/app/models/event_import_file_transition.rb
+++ b/app/models/event_import_file_transition.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: event_import_file_transitions
 #
-#  id                   :integer          not null, primary key
+#  id                   :bigint           not null, primary key
 #  to_state             :string
 #  metadata             :text             default({})
 #  sort_key             :integer

--- a/app/models/event_import_result.rb
+++ b/app/models/event_import_result.rb
@@ -16,7 +16,7 @@ end
 #
 # Table name: event_import_results
 #
-#  id                   :integer          not null, primary key
+#  id                   :bigint           not null, primary key
 #  event_import_file_id :integer
 #  event_id             :integer
 #  body                 :text

--- a/app/models/form_of_work.rb
+++ b/app/models/form_of_work.rb
@@ -7,7 +7,7 @@ end
 #
 # Table name: form_of_works
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/app/models/frequency.rb
+++ b/app/models/frequency.rb
@@ -7,7 +7,7 @@ end
 #
 # Table name: frequencies
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/app/models/identifier.rb
+++ b/app/models/identifier.rb
@@ -76,7 +76,7 @@ end
 #
 # Table name: identifiers
 #
-#  id                 :integer          not null, primary key
+#  id                 :bigint           not null, primary key
 #  body               :string           not null
 #  identifier_type_id :integer          not null
 #  manifestation_id   :integer

--- a/app/models/identifier_type.rb
+++ b/app/models/identifier_type.rb
@@ -8,8 +8,8 @@ end
 #
 # Table name: identifier_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -12,8 +12,8 @@ end
 #
 # Table name: identities
 #
-#  id              :integer          not null, primary key
-#  name            :string
+#  id              :bigint           not null, primary key
+#  name            :string           not null
 #  email           :string
 #  password_digest :string
 #  profile_id      :integer

--- a/app/models/import_request.rb
+++ b/app/models/import_request.rb
@@ -70,7 +70,7 @@ end
 #
 # Table name: import_requests
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  isbn             :string
 #  manifestation_id :integer
 #  user_id          :integer

--- a/app/models/import_request_transition.rb
+++ b/app/models/import_request_transition.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: import_request_transitions
 #
-#  id                :integer          not null, primary key
+#  id                :bigint           not null, primary key
 #  to_state          :string
 #  metadata          :text             default({})
 #  sort_key          :integer

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -38,7 +38,7 @@ end
 #
 # Table name: inventories
 #
-#  id                 :integer          not null, primary key
+#  id                 :bigint           not null, primary key
 #  item_id            :integer
 #  inventory_file_id  :integer
 #  note               :text

--- a/app/models/inventory_file.rb
+++ b/app/models/inventory_file.rb
@@ -69,7 +69,7 @@ end
 #
 # Table name: inventory_files
 #
-#  id                     :integer          not null, primary key
+#  id                     :bigint           not null, primary key
 #  filename               :string
 #  content_type           :string
 #  size                   :integer

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -152,7 +152,7 @@ end
 #
 # Table name: items
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  call_number             :string
 #  item_identifier         :string
 #  created_at              :datetime         not null

--- a/app/models/item_has_use_restriction.rb
+++ b/app/models/item_has_use_restriction.rb
@@ -12,7 +12,7 @@ end
 #
 # Table name: item_has_use_restrictions
 #
-#  id                 :integer          not null, primary key
+#  id                 :bigint           not null, primary key
 #  item_id            :integer          not null
 #  use_restriction_id :integer          not null
 #  created_at         :datetime         not null

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -24,7 +24,7 @@ end
 #
 # Table name: languages
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  native_name  :string
 #  display_name :text

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -82,7 +82,7 @@ end
 #
 # Table name: libraries
 #
-#  id                    :integer          not null, primary key
+#  id                    :bigint           not null, primary key
 #  name                  :string           not null
 #  display_name          :text
 #  short_display_name    :string           not null

--- a/app/models/library_group.rb
+++ b/app/models/library_group.rb
@@ -83,7 +83,7 @@ end
 #
 # Table name: library_groups
 #
-#  id                            :integer          not null, primary key
+#  id                            :bigint           not null, primary key
 #  name                          :string           not null
 #  display_name                  :text
 #  short_name                    :string           not null

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -6,7 +6,7 @@ end
 #
 # Table name: licenses
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :string
 #  note         :text

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -713,7 +713,7 @@ end
 #
 # Table name: manifestations
 #
-#  id                              :integer          not null, primary key
+#  id                              :bigint           not null, primary key
 #  original_title                  :text             not null
 #  title_alternative               :text
 #  title_transcription             :text

--- a/app/models/manifestation_checkout_stat.rb
+++ b/app/models/manifestation_checkout_stat.rb
@@ -48,7 +48,7 @@ end
 #
 # Table name: manifestation_checkout_stats
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text

--- a/app/models/manifestation_checkout_stat_transition.rb
+++ b/app/models/manifestation_checkout_stat_transition.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: manifestation_checkout_stat_transitions
 #
-#  id                             :integer          not null, primary key
+#  id                             :bigint           not null, primary key
 #  to_state                       :string
 #  metadata                       :text             default({})
 #  sort_key                       :integer

--- a/app/models/manifestation_relationship.rb
+++ b/app/models/manifestation_relationship.rb
@@ -17,7 +17,7 @@ end
 #
 # Table name: manifestation_relationships
 #
-#  id                                 :integer          not null, primary key
+#  id                                 :bigint           not null, primary key
 #  parent_id                          :integer
 #  child_id                           :integer
 #  manifestation_relationship_type_id :integer

--- a/app/models/manifestation_relationship_type.rb
+++ b/app/models/manifestation_relationship_type.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: manifestation_relationship_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/app/models/manifestation_reserve_stat.rb
+++ b/app/models/manifestation_reserve_stat.rb
@@ -48,7 +48,7 @@ end
 #
 # Table name: manifestation_reserve_stats
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text

--- a/app/models/manifestation_reserve_stat_transition.rb
+++ b/app/models/manifestation_reserve_stat_transition.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: manifestation_reserve_stat_transitions
 #
-#  id                            :integer          not null, primary key
+#  id                            :bigint           not null, primary key
 #  to_state                      :string
 #  metadata                      :text             default({})
 #  sort_key                      :integer

--- a/app/models/medium_of_performance.rb
+++ b/app/models/medium_of_performance.rb
@@ -7,7 +7,7 @@ end
 #
 # Table name: medium_of_performances
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/app/models/news_feed.rb
+++ b/app/models/news_feed.rb
@@ -56,7 +56,7 @@ end
 #
 # Table name: news_feeds
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  library_group_id :integer          default(1), not null
 #  title            :string
 #  url              :string

--- a/app/models/news_post.rb
+++ b/app/models/news_post.rb
@@ -34,7 +34,7 @@ end
 #
 # Table name: news_posts
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  title            :text
 #  body             :text
 #  user_id          :integer

--- a/app/models/nii_type.rb
+++ b/app/models/nii_type.rb
@@ -7,7 +7,7 @@ end
 #
 # Table name: nii_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/app/models/own.rb
+++ b/app/models/own.rb
@@ -20,7 +20,7 @@ end
 #
 # Table name: owns
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  agent_id   :integer          not null
 #  item_id    :integer          not null
 #  position   :integer

--- a/app/models/participate.rb
+++ b/app/models/participate.rb
@@ -12,7 +12,7 @@ end
 #
 # Table name: participates
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  agent_id   :integer          not null
 #  event_id   :integer          not null
 #  position   :integer

--- a/app/models/picture_file.rb
+++ b/app/models/picture_file.rb
@@ -43,7 +43,7 @@ end
 #
 # Table name: picture_files
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  picture_attachable_id   :integer
 #  picture_attachable_type :string
 #  title                   :text

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -7,7 +7,7 @@ end
 #
 # Table name: places
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  term       :string
 #  city       :text
 #  country_id :integer

--- a/app/models/produce.rb
+++ b/app/models/produce.rb
@@ -20,7 +20,7 @@ end
 #
 # Table name: produces
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  agent_id         :integer          not null
 #  manifestation_id :integer          not null
 #  position         :integer

--- a/app/models/produce_type.rb
+++ b/app/models/produce_type.rb
@@ -7,8 +7,8 @@ end
 #
 # Table name: produce_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -77,7 +77,7 @@ end
 #
 # Table name: profiles
 #
-#  id                       :integer          not null, primary key
+#  id                       :bigint           not null, primary key
 #  user_id                  :integer
 #  user_group_id            :integer
 #  library_id               :integer

--- a/app/models/realize.rb
+++ b/app/models/realize.rb
@@ -19,7 +19,7 @@ end
 #
 # Table name: realizes
 #
-#  id              :integer          not null, primary key
+#  id              :bigint           not null, primary key
 #  agent_id        :integer          not null
 #  expression_id   :integer          not null
 #  position        :integer

--- a/app/models/realize_type.rb
+++ b/app/models/realize_type.rb
@@ -7,8 +7,8 @@ end
 #
 # Table name: realize_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/app/models/request_status_type.rb
+++ b/app/models/request_status_type.rb
@@ -14,7 +14,7 @@ end
 #
 # Table name: request_status_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/app/models/request_type.rb
+++ b/app/models/request_type.rb
@@ -13,7 +13,7 @@ end
 #
 # Table name: request_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/app/models/reserve.rb
+++ b/app/models/reserve.rb
@@ -320,7 +320,7 @@ end
 #
 # Table name: reserves
 #
-#  id                           :integer          not null, primary key
+#  id                           :bigint           not null, primary key
 #  user_id                      :integer          not null
 #  manifestation_id             :integer          not null
 #  item_id                      :integer

--- a/app/models/reserve_stat_has_manifestation.rb
+++ b/app/models/reserve_stat_has_manifestation.rb
@@ -11,7 +11,7 @@ end
 #
 # Table name: reserve_stat_has_manifestations
 #
-#  id                            :integer          not null, primary key
+#  id                            :bigint           not null, primary key
 #  manifestation_reserve_stat_id :integer          not null
 #  manifestation_id              :integer          not null
 #  reserves_count                :integer

--- a/app/models/reserve_stat_has_user.rb
+++ b/app/models/reserve_stat_has_user.rb
@@ -11,7 +11,7 @@ end
 #
 # Table name: reserve_stat_has_users
 #
-#  id                   :integer          not null, primary key
+#  id                   :bigint           not null, primary key
 #  user_reserve_stat_id :integer          not null
 #  user_id              :integer          not null
 #  reserves_count       :integer

--- a/app/models/reserve_transition.rb
+++ b/app/models/reserve_transition.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: reserve_transitions
 #
-#  id          :integer          not null, primary key
+#  id          :bigint           not null, primary key
 #  to_state    :string
 #  metadata    :text             default({})
 #  sort_key    :integer

--- a/app/models/resource_export_file.rb
+++ b/app/models/resource_export_file.rb
@@ -54,7 +54,7 @@ end
 #
 # Table name: resource_export_files
 #
-#  id                           :integer          not null, primary key
+#  id                           :bigint           not null, primary key
 #  user_id                      :integer
 #  resource_export_file_name    :string
 #  resource_export_content_type :string

--- a/app/models/resource_export_file_transition.rb
+++ b/app/models/resource_export_file_transition.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: resource_export_file_transitions
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  to_state                :string
 #  metadata                :text             default({})
 #  sort_key                :integer

--- a/app/models/resource_import_file.rb
+++ b/app/models/resource_import_file.rb
@@ -889,7 +889,7 @@ end
 #
 # Table name: resource_import_files
 #
-#  id                           :integer          not null, primary key
+#  id                           :bigint           not null, primary key
 #  parent_id                    :integer
 #  content_type                 :string
 #  size                         :integer

--- a/app/models/resource_import_file_transition.rb
+++ b/app/models/resource_import_file_transition.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: resource_import_file_transitions
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  to_state                :string
 #  metadata                :text             default({})
 #  sort_key                :integer

--- a/app/models/resource_import_result.rb
+++ b/app/models/resource_import_result.rb
@@ -13,7 +13,7 @@ end
 #
 # Table name: resource_import_results
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  resource_import_file_id :integer
 #  manifestation_id        :integer
 #  item_id                 :integer

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -26,7 +26,7 @@ end
 #
 # Table name: roles
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :string
 #  note         :text

--- a/app/models/search_engine.rb
+++ b/app/models/search_engine.rb
@@ -25,7 +25,7 @@ end
 #
 # Table name: search_engines
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  name             :string           not null
 #  display_name     :text
 #  url              :string           not null

--- a/app/models/series_statement.rb
+++ b/app/models/series_statement.rb
@@ -51,7 +51,7 @@ end
 #
 # Table name: series_statements
 #
-#  id                                 :integer          not null, primary key
+#  id                                 :bigint           not null, primary key
 #  original_title                     :text
 #  numbering                          :text
 #  title_subseries                    :text

--- a/app/models/series_statement_merge.rb
+++ b/app/models/series_statement_merge.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: series_statement_merges
 #
-#  id                             :integer          not null, primary key
+#  id                             :bigint           not null, primary key
 #  series_statement_id            :integer          not null
 #  series_statement_merge_list_id :integer          not null
 #  created_at                     :datetime         not null

--- a/app/models/series_statement_merge_list.rb
+++ b/app/models/series_statement_merge_list.rb
@@ -10,7 +10,7 @@ end
 #
 # Table name: series_statement_merge_lists
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/shelf.rb
+++ b/app/models/shelf.rb
@@ -52,7 +52,7 @@ end
 #
 # Table name: shelves
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -21,7 +21,7 @@ end
 #
 # Table name: subjects
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  parent_id               :integer
 #  use_term_id             :integer
 #  term                    :string

--- a/app/models/subject_heading_type.rb
+++ b/app/models/subject_heading_type.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: subject_heading_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/app/models/subject_type.rb
+++ b/app/models/subject_type.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: subject_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/app/models/subscribe.rb
+++ b/app/models/subscribe.rb
@@ -10,7 +10,7 @@ end
 #
 # Table name: subscribes
 #
-#  id              :integer          not null, primary key
+#  id              :bigint           not null, primary key
 #  subscription_id :integer          not null
 #  work_id         :integer          not null
 #  start_at        :datetime         not null

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -26,7 +26,7 @@ end
 #
 # Table name: subscriptions
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  title            :text             not null
 #  note             :text
 #  user_id          :integer

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -47,8 +47,8 @@ end
 #
 # Table name: tags
 #
-#  id             :integer          not null, primary key
-#  name           :string
+#  id             :bigint           not null, primary key
+#  name           :string           not null
 #  taggings_count :integer          default(0)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null

--- a/app/models/use_restriction.rb
+++ b/app/models/use_restriction.rb
@@ -17,7 +17,7 @@ end
 #
 # Table name: use_restrictions
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/app/models/user_checkout_stat.rb
+++ b/app/models/user_checkout_stat.rb
@@ -47,7 +47,7 @@ end
 #
 # Table name: user_checkout_stats
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text

--- a/app/models/user_checkout_stat_transition.rb
+++ b/app/models/user_checkout_stat_transition.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: user_checkout_stat_transitions
 #
-#  id                    :integer          not null, primary key
+#  id                    :bigint           not null, primary key
 #  to_state              :string
 #  metadata              :text             default({})
 #  sort_key              :integer

--- a/app/models/user_export_file.rb
+++ b/app/models/user_export_file.rb
@@ -54,7 +54,7 @@ end
 #
 # Table name: user_export_files
 #
-#  id                       :integer          not null, primary key
+#  id                       :bigint           not null, primary key
 #  user_id                  :integer
 #  user_export_file_name    :string
 #  user_export_content_type :string

--- a/app/models/user_export_file_transition.rb
+++ b/app/models/user_export_file_transition.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: user_export_file_transitions
 #
-#  id                  :integer          not null, primary key
+#  id                  :bigint           not null, primary key
 #  to_state            :string
 #  metadata            :text             default({})
 #  sort_key            :integer

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -14,8 +14,8 @@ end
 #
 # Table name: user_groups
 #
-#  id                               :integer          not null, primary key
-#  name                             :string
+#  id                               :bigint           not null, primary key
+#  name                             :string           not null
 #  display_name                     :text
 #  note                             :text
 #  position                         :integer

--- a/app/models/user_group_has_checkout_type.rb
+++ b/app/models/user_group_has_checkout_type.rb
@@ -44,7 +44,7 @@ end
 #
 # Table name: user_group_has_checkout_types
 #
-#  id                              :integer          not null, primary key
+#  id                              :bigint           not null, primary key
 #  user_group_id                   :integer          not null
 #  checkout_type_id                :integer          not null
 #  checkout_limit                  :integer          default(0), not null

--- a/app/models/user_has_role.rb
+++ b/app/models/user_has_role.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: user_has_roles
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  user_id    :integer          not null
 #  role_id    :integer          not null
 #  created_at :datetime         not null

--- a/app/models/user_import_file.rb
+++ b/app/models/user_import_file.rb
@@ -331,7 +331,7 @@ end
 #
 # Table name: user_import_files
 #
-#  id                       :integer          not null, primary key
+#  id                       :bigint           not null, primary key
 #  user_id                  :integer
 #  note                     :text
 #  executed_at              :datetime

--- a/app/models/user_import_file_transition.rb
+++ b/app/models/user_import_file_transition.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: user_import_file_transitions
 #
-#  id                  :integer          not null, primary key
+#  id                  :bigint           not null, primary key
 #  to_state            :string
 #  metadata            :text             default({})
 #  sort_key            :integer

--- a/app/models/user_import_result.rb
+++ b/app/models/user_import_result.rb
@@ -10,7 +10,7 @@ end
 #
 # Table name: user_import_results
 #
-#  id                  :integer          not null, primary key
+#  id                  :bigint           not null, primary key
 #  user_import_file_id :integer
 #  user_id             :integer
 #  body                :text

--- a/app/models/user_reserve_stat.rb
+++ b/app/models/user_reserve_stat.rb
@@ -47,7 +47,7 @@ end
 #
 # Table name: user_reserve_stats
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text

--- a/app/models/user_reserve_stat_transition.rb
+++ b/app/models/user_reserve_stat_transition.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: user_reserve_stat_transitions
 #
-#  id                   :integer          not null, primary key
+#  id                   :bigint           not null, primary key
 #  to_state             :string
 #  metadata             :text             default({})
 #  sort_key             :integer

--- a/app/models/withdraw.rb
+++ b/app/models/withdraw.rb
@@ -16,7 +16,7 @@ end
 #
 # Table name: withdraws
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  basket_id    :integer
 #  item_id      :integer
 #  librarian_id :integer

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_12_065100) do
+ActiveRecord::Schema.define(version: 2022_11_12_152252) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "accepts", id: :serial, force: :cascade do |t|
+  create_table "accepts", force: :cascade do |t|
     t.integer "basket_id"
     t.integer "item_id"
     t.integer "librarian_id"
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["librarian_id"], name: "index_accepts_on_librarian_id"
   end
 
-  create_table "agent_import_file_transitions", id: :serial, force: :cascade do |t|
+  create_table "agent_import_file_transitions", force: :cascade do |t|
     t.string "to_state"
     t.text "metadata", default: "{}"
     t.integer "sort_key"
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["sort_key", "agent_import_file_id"], name: "index_agent_import_file_transitions_on_sort_key_and_file_id", unique: true
   end
 
-  create_table "agent_import_files", id: :serial, force: :cascade do |t|
+  create_table "agent_import_files", force: :cascade do |t|
     t.integer "parent_id"
     t.string "content_type"
     t.integer "size"
@@ -60,7 +60,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_id"], name: "index_agent_import_files_on_user_id"
   end
 
-  create_table "agent_import_results", id: :serial, force: :cascade do |t|
+  create_table "agent_import_results", force: :cascade do |t|
     t.integer "agent_import_file_id"
     t.integer "agent_id"
     t.text "body"
@@ -68,13 +68,13 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "agent_merge_lists", id: :serial, force: :cascade do |t|
+  create_table "agent_merge_lists", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "agent_merges", id: :serial, force: :cascade do |t|
+  create_table "agent_merges", force: :cascade do |t|
     t.integer "agent_id", null: false
     t.integer "agent_merge_list_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -83,16 +83,17 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["agent_merge_list_id"], name: "index_agent_merges_on_agent_merge_list_id"
   end
 
-  create_table "agent_relationship_types", id: :serial, force: :cascade do |t|
+  create_table "agent_relationship_types", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_agent_relationship_types_on_lower_name", unique: true
   end
 
-  create_table "agent_relationships", id: :serial, force: :cascade do |t|
+  create_table "agent_relationships", force: :cascade do |t|
     t.integer "parent_id"
     t.integer "child_id"
     t.integer "agent_relationship_type_id"
@@ -103,16 +104,17 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["parent_id"], name: "index_agent_relationships_on_parent_id"
   end
 
-  create_table "agent_types", id: :serial, force: :cascade do |t|
+  create_table "agent_types", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_agent_types_on_lower_name", unique: true
   end
 
-  create_table "agents", id: :serial, force: :cascade do |t|
+  create_table "agents", force: :cascade do |t|
     t.string "last_name"
     t.string "middle_name"
     t.string "first_name"
@@ -166,7 +168,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["required_role_id"], name: "index_agents_on_required_role_id"
   end
 
-  create_table "baskets", id: :serial, force: :cascade do |t|
+  create_table "baskets", force: :cascade do |t|
     t.integer "user_id"
     t.text "note"
     t.integer "lock_version", default: 0, null: false
@@ -175,7 +177,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_id"], name: "index_baskets_on_user_id"
   end
 
-  create_table "bookmark_stat_has_manifestations", id: :serial, force: :cascade do |t|
+  create_table "bookmark_stat_has_manifestations", force: :cascade do |t|
     t.integer "bookmark_stat_id", null: false
     t.integer "manifestation_id", null: false
     t.integer "bookmarks_count"
@@ -185,7 +187,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["manifestation_id"], name: "index_bookmark_stat_has_manifestations_on_manifestation_id"
   end
 
-  create_table "bookmark_stat_transitions", id: :serial, force: :cascade do |t|
+  create_table "bookmark_stat_transitions", force: :cascade do |t|
     t.string "to_state"
     t.text "metadata", default: "{}"
     t.integer "sort_key"
@@ -198,7 +200,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["sort_key", "bookmark_stat_id"], name: "index_bookmark_stat_transitions_on_sort_key_and_stat_id", unique: true
   end
 
-  create_table "bookmark_stats", id: :serial, force: :cascade do |t|
+  create_table "bookmark_stats", force: :cascade do |t|
     t.datetime "start_date"
     t.datetime "end_date"
     t.datetime "started_at"
@@ -208,7 +210,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "bookmarks", id: :serial, force: :cascade do |t|
+  create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "manifestation_id"
     t.text "title"
@@ -222,7 +224,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "bookstores", id: :serial, force: :cascade do |t|
+  create_table "bookstores", force: :cascade do |t|
     t.text "name", null: false
     t.string "zip_code"
     t.text "address"
@@ -235,16 +237,17 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "budget_types", id: :serial, force: :cascade do |t|
-    t.string "name"
+  create_table "budget_types", force: :cascade do |t|
+    t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_budget_types_on_lower_name", unique: true
   end
 
-  create_table "carrier_type_has_checkout_types", id: :serial, force: :cascade do |t|
+  create_table "carrier_type_has_checkout_types", force: :cascade do |t|
     t.integer "carrier_type_id", null: false
     t.integer "checkout_type_id", null: false
     t.text "note"
@@ -255,7 +258,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["checkout_type_id"], name: "index_carrier_type_has_checkout_types_on_checkout_type_id"
   end
 
-  create_table "carrier_types", id: :serial, force: :cascade do |t|
+  create_table "carrier_types", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.text "note"
@@ -266,9 +269,10 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.string "attachment_content_type"
     t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
+    t.index "lower((name)::text)", name: "index_carrier_types_on_lower_name", unique: true
   end
 
-  create_table "checked_items", id: :serial, force: :cascade do |t|
+  create_table "checked_items", force: :cascade do |t|
     t.integer "item_id", null: false
     t.integer "basket_id", null: false
     t.integer "librarian_id"
@@ -282,7 +286,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_id"], name: "index_checked_items_on_user_id"
   end
 
-  create_table "checkins", id: :serial, force: :cascade do |t|
+  create_table "checkins", force: :cascade do |t|
     t.integer "item_id", null: false
     t.integer "librarian_id"
     t.integer "basket_id"
@@ -294,7 +298,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["librarian_id"], name: "index_checkins_on_librarian_id"
   end
 
-  create_table "checkout_stat_has_manifestations", id: :serial, force: :cascade do |t|
+  create_table "checkout_stat_has_manifestations", force: :cascade do |t|
     t.integer "manifestation_checkout_stat_id", null: false
     t.integer "manifestation_id", null: false
     t.integer "checkouts_count"
@@ -304,7 +308,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["manifestation_id"], name: "index_checkout_stat_has_manifestations_on_manifestation_id"
   end
 
-  create_table "checkout_stat_has_users", id: :serial, force: :cascade do |t|
+  create_table "checkout_stat_has_users", force: :cascade do |t|
     t.integer "user_checkout_stat_id", null: false
     t.integer "user_id", null: false
     t.integer "checkouts_count", default: 0, null: false
@@ -314,17 +318,17 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_id"], name: "index_checkout_stat_has_users_on_user_id"
   end
 
-  create_table "checkout_types", id: :serial, force: :cascade do |t|
+  create_table "checkout_types", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["name"], name: "index_checkout_types_on_name"
+    t.index "lower((name)::text)", name: "index_checkout_types_on_lower_name", unique: true
   end
 
-  create_table "checkouts", id: :serial, force: :cascade do |t|
+  create_table "checkouts", force: :cascade do |t|
     t.integer "user_id"
     t.integer "item_id", null: false
     t.integer "checkin_id"
@@ -347,25 +351,27 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_id"], name: "index_checkouts_on_user_id"
   end
 
-  create_table "circulation_statuses", id: :serial, force: :cascade do |t|
+  create_table "circulation_statuses", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_circulation_statuses_on_lower_name", unique: true
   end
 
-  create_table "classification_types", id: :serial, force: :cascade do |t|
+  create_table "classification_types", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_classification_types_on_lower_name", unique: true
   end
 
-  create_table "classifications", id: :serial, force: :cascade do |t|
+  create_table "classifications", force: :cascade do |t|
     t.integer "parent_id"
     t.string "category", null: false
     t.text "note"
@@ -383,7 +389,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["parent_id"], name: "index_classifications_on_parent_id"
   end
 
-  create_table "colors", id: :serial, force: :cascade do |t|
+  create_table "colors", force: :cascade do |t|
     t.integer "library_group_id"
     t.string "property"
     t.string "code"
@@ -393,16 +399,17 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["library_group_id"], name: "index_colors_on_library_group_id"
   end
 
-  create_table "content_types", id: :serial, force: :cascade do |t|
+  create_table "content_types", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_content_types_on_lower_name", unique: true
   end
 
-  create_table "countries", id: :serial, force: :cascade do |t|
+  create_table "countries", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.string "alpha_2"
@@ -410,22 +417,23 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.string "numeric_3"
     t.text "note"
     t.integer "position"
+    t.index "lower((name)::text)", name: "index_countries_on_lower_name", unique: true
     t.index ["alpha_2"], name: "index_countries_on_alpha_2"
     t.index ["alpha_3"], name: "index_countries_on_alpha_3"
-    t.index ["name"], name: "index_countries_on_name"
     t.index ["numeric_3"], name: "index_countries_on_numeric_3"
   end
 
-  create_table "create_types", id: :serial, force: :cascade do |t|
-    t.string "name"
+  create_table "create_types", force: :cascade do |t|
+    t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_create_types_on_lower_name", unique: true
   end
 
-  create_table "creates", id: :serial, force: :cascade do |t|
+  create_table "creates", force: :cascade do |t|
     t.integer "agent_id", null: false
     t.integer "work_id", null: false
     t.integer "position"
@@ -436,7 +444,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["work_id", "agent_id"], name: "index_creates_on_work_id_and_agent_id", unique: true
   end
 
-  create_table "demands", id: :serial, force: :cascade do |t|
+  create_table "demands", force: :cascade do |t|
     t.integer "user_id"
     t.integer "item_id"
     t.integer "message_id"
@@ -447,7 +455,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_id"], name: "index_demands_on_user_id"
   end
 
-  create_table "donates", id: :serial, force: :cascade do |t|
+  create_table "donates", force: :cascade do |t|
     t.integer "agent_id", null: false
     t.integer "item_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -456,7 +464,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["item_id"], name: "index_donates_on_item_id"
   end
 
-  create_table "event_categories", id: :serial, force: :cascade do |t|
+  create_table "event_categories", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.text "note"
@@ -465,7 +473,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "event_export_file_transitions", id: :serial, force: :cascade do |t|
+  create_table "event_export_file_transitions", force: :cascade do |t|
     t.string "to_state"
     t.text "metadata", default: "{}"
     t.integer "sort_key"
@@ -478,7 +486,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["sort_key", "event_export_file_id"], name: "index_event_export_file_transitions_on_sort_key_and_file_id", unique: true
   end
 
-  create_table "event_export_files", id: :serial, force: :cascade do |t|
+  create_table "event_export_files", force: :cascade do |t|
     t.integer "user_id"
     t.string "event_export_file_name"
     t.string "event_export_content_type"
@@ -490,7 +498,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_id"], name: "index_event_export_files_on_user_id"
   end
 
-  create_table "event_import_file_transitions", id: :serial, force: :cascade do |t|
+  create_table "event_import_file_transitions", force: :cascade do |t|
     t.string "to_state"
     t.text "metadata", default: "{}"
     t.integer "sort_key"
@@ -503,7 +511,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["sort_key", "event_import_file_id"], name: "index_event_import_file_transitions_on_sort_key_and_file_id", unique: true
   end
 
-  create_table "event_import_files", id: :serial, force: :cascade do |t|
+  create_table "event_import_files", force: :cascade do |t|
     t.integer "parent_id"
     t.string "content_type"
     t.integer "size"
@@ -526,7 +534,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_id"], name: "index_event_import_files_on_user_id"
   end
 
-  create_table "event_import_results", id: :serial, force: :cascade do |t|
+  create_table "event_import_results", force: :cascade do |t|
     t.integer "event_import_file_id"
     t.integer "event_id"
     t.text "body"
@@ -534,10 +542,10 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "events", id: :serial, force: :cascade do |t|
+  create_table "events", force: :cascade do |t|
     t.integer "library_id", null: false
     t.integer "event_category_id", null: false
-    t.string "name"
+    t.string "name", null: false
     t.text "note"
     t.datetime "start_at"
     t.datetime "end_at"
@@ -551,34 +559,37 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["place_id"], name: "index_events_on_place_id"
   end
 
-  create_table "form_of_works", id: :serial, force: :cascade do |t|
+  create_table "form_of_works", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_form_of_works_on_lower_name", unique: true
   end
 
-  create_table "frequencies", id: :serial, force: :cascade do |t|
+  create_table "frequencies", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_frequencies_on_lower_name", unique: true
   end
 
-  create_table "identifier_types", id: :serial, force: :cascade do |t|
-    t.string "name"
+  create_table "identifier_types", force: :cascade do |t|
+    t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_identifier_types_on_lower_name", unique: true
   end
 
-  create_table "identifiers", id: :serial, force: :cascade do |t|
+  create_table "identifiers", force: :cascade do |t|
     t.string "body", null: false
     t.integer "identifier_type_id", null: false
     t.integer "manifestation_id"
@@ -590,8 +601,8 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["manifestation_id"], name: "index_identifiers_on_manifestation_id"
   end
 
-  create_table "identities", id: :serial, force: :cascade do |t|
-    t.string "name"
+  create_table "identities", force: :cascade do |t|
+    t.string "name", null: false
     t.string "email"
     t.string "password_digest"
     t.integer "profile_id"
@@ -603,7 +614,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["profile_id"], name: "index_identities_on_profile_id"
   end
 
-  create_table "import_request_transitions", id: :serial, force: :cascade do |t|
+  create_table "import_request_transitions", force: :cascade do |t|
     t.string "to_state"
     t.text "metadata", default: "{}"
     t.integer "sort_key"
@@ -616,7 +627,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["sort_key", "import_request_id"], name: "index_import_request_transitions_on_sort_key_and_request_id", unique: true
   end
 
-  create_table "import_requests", id: :serial, force: :cascade do |t|
+  create_table "import_requests", force: :cascade do |t|
     t.string "isbn"
     t.integer "manifestation_id"
     t.integer "user_id"
@@ -627,7 +638,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_id"], name: "index_import_requests_on_user_id"
   end
 
-  create_table "inventories", id: :serial, force: :cascade do |t|
+  create_table "inventories", force: :cascade do |t|
     t.integer "item_id"
     t.integer "inventory_file_id"
     t.text "note"
@@ -641,7 +652,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["item_identifier"], name: "index_inventories_on_item_identifier"
   end
 
-  create_table "inventory_files", id: :serial, force: :cascade do |t|
+  create_table "inventory_files", force: :cascade do |t|
     t.string "filename"
     t.string "content_type"
     t.integer "size"
@@ -666,7 +677,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.integer "position", default: 1, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["name"], name: "index_item_custom_properties_on_name", unique: true
+    t.index "lower((name)::text)", name: "index_item_custom_properties_on_lower_name", unique: true
   end
 
   create_table "item_custom_values", force: :cascade do |t|
@@ -680,7 +691,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["item_id"], name: "index_item_custom_values_on_item_id"
   end
 
-  create_table "item_has_use_restrictions", id: :serial, force: :cascade do |t|
+  create_table "item_has_use_restrictions", force: :cascade do |t|
     t.integer "item_id", null: false
     t.integer "use_restriction_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -689,7 +700,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["use_restriction_id"], name: "index_item_has_use_restrictions_on_use_restriction_id"
   end
 
-  create_table "items", id: :serial, force: :cascade do |t|
+  create_table "items", force: :cascade do |t|
     t.string "call_number"
     t.string "item_identifier"
     t.datetime "created_at", precision: 6, null: false
@@ -732,7 +743,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["manifestation_id"], name: "index_jpno_records_on_manifestation_id"
   end
 
-  create_table "languages", id: :serial, force: :cascade do |t|
+  create_table "languages", force: :cascade do |t|
     t.string "name", null: false
     t.string "native_name"
     t.text "display_name"
@@ -741,13 +752,13 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.string "iso_639_3"
     t.text "note"
     t.integer "position"
+    t.index "lower((name)::text)", name: "index_languages_on_lower_name", unique: true
     t.index ["iso_639_1"], name: "index_languages_on_iso_639_1"
     t.index ["iso_639_2"], name: "index_languages_on_iso_639_2"
     t.index ["iso_639_3"], name: "index_languages_on_iso_639_3"
-    t.index ["name"], name: "index_languages_on_name", unique: true
   end
 
-  create_table "libraries", id: :serial, force: :cascade do |t|
+  create_table "libraries", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.string "short_display_name", null: false
@@ -771,8 +782,8 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.string "isil"
     t.float "latitude"
     t.float "longitude"
+    t.index "lower((name)::text)", name: "index_libraries_on_lower_name", unique: true
     t.index ["library_group_id"], name: "index_libraries_on_library_group_id"
-    t.index ["name"], name: "index_libraries_on_name"
   end
 
   create_table "library_group_translations", force: :cascade do |t|
@@ -786,7 +797,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["locale"], name: "index_library_group_translations_on_locale"
   end
 
-  create_table "library_groups", id: :serial, force: :cascade do |t|
+  create_table "library_groups", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.string "short_name", null: false
@@ -814,20 +825,22 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.bigint "header_logo_file_size"
     t.datetime "header_logo_updated_at"
     t.text "header_logo_meta"
+    t.index "lower((name)::text)", name: "index_library_groups_on_lower_name", unique: true
     t.index ["short_name"], name: "index_library_groups_on_short_name"
     t.index ["user_id"], name: "index_library_groups_on_user_id"
   end
 
-  create_table "licenses", id: :serial, force: :cascade do |t|
+  create_table "licenses", force: :cascade do |t|
     t.string "name", null: false
     t.string "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_licenses_on_lower_name", unique: true
   end
 
-  create_table "manifestation_checkout_stat_transitions", id: :serial, force: :cascade do |t|
+  create_table "manifestation_checkout_stat_transitions", force: :cascade do |t|
     t.string "to_state"
     t.text "metadata", default: "{}"
     t.integer "sort_key"
@@ -840,7 +853,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["sort_key", "manifestation_checkout_stat_id"], name: "index_manifestation_checkout_stat_transitions_on_transition", unique: true
   end
 
-  create_table "manifestation_checkout_stats", id: :serial, force: :cascade do |t|
+  create_table "manifestation_checkout_stats", force: :cascade do |t|
     t.datetime "start_date"
     t.datetime "end_date"
     t.text "note"
@@ -859,7 +872,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.integer "position", default: 1, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["name"], name: "index_manifestation_custom_properties_on_name", unique: true
+    t.index "lower((name)::text)", name: "index_manifestation_custom_properties_on_lower_name", unique: true
   end
 
   create_table "manifestation_custom_values", force: :cascade do |t|
@@ -873,16 +886,17 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["manifestation_id"], name: "index_manifestation_custom_values_on_manifestation_id"
   end
 
-  create_table "manifestation_relationship_types", id: :serial, force: :cascade do |t|
+  create_table "manifestation_relationship_types", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_manifestation_relationship_types_on_lower_name", unique: true
   end
 
-  create_table "manifestation_relationships", id: :serial, force: :cascade do |t|
+  create_table "manifestation_relationships", force: :cascade do |t|
     t.integer "parent_id"
     t.integer "child_id"
     t.integer "manifestation_relationship_type_id"
@@ -893,7 +907,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["parent_id"], name: "index_manifestation_relationships_on_parent_id"
   end
 
-  create_table "manifestation_reserve_stat_transitions", id: :serial, force: :cascade do |t|
+  create_table "manifestation_reserve_stat_transitions", force: :cascade do |t|
     t.string "to_state"
     t.text "metadata", default: "{}"
     t.integer "sort_key"
@@ -906,7 +920,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["sort_key", "manifestation_reserve_stat_id"], name: "index_manifestation_reserve_stat_transitions_on_transition", unique: true
   end
 
-  create_table "manifestation_reserve_stats", id: :serial, force: :cascade do |t|
+  create_table "manifestation_reserve_stats", force: :cascade do |t|
     t.datetime "start_date"
     t.datetime "end_date"
     t.text "note"
@@ -918,7 +932,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_id"], name: "index_manifestation_reserve_stats_on_user_id"
   end
 
-  create_table "manifestations", id: :serial, force: :cascade do |t|
+  create_table "manifestations", force: :cascade do |t|
     t.text "original_title", null: false
     t.text "title_alternative"
     t.text "title_transcription"
@@ -985,13 +999,14 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["updated_at"], name: "index_manifestations_on_updated_at"
   end
 
-  create_table "medium_of_performances", id: :serial, force: :cascade do |t|
+  create_table "medium_of_performances", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_medium_of_performances_on_lower_name", unique: true
   end
 
   create_table "message_transitions", force: :cascade do |t|
@@ -1044,7 +1059,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["body"], name: "index_ndla_records_on_body", unique: true
   end
 
-  create_table "news_feeds", id: :serial, force: :cascade do |t|
+  create_table "news_feeds", force: :cascade do |t|
     t.integer "library_group_id", default: 1, null: false
     t.string "title"
     t.string "url"
@@ -1054,7 +1069,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "news_posts", id: :serial, force: :cascade do |t|
+  create_table "news_posts", force: :cascade do |t|
     t.text "title"
     t.text "body"
     t.integer "user_id"
@@ -1070,17 +1085,17 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_id"], name: "index_news_posts_on_user_id"
   end
 
-  create_table "nii_types", id: :serial, force: :cascade do |t|
+  create_table "nii_types", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["name"], name: "index_nii_types_on_name", unique: true
+    t.index "lower((name)::text)", name: "index_nii_types_on_lower_name", unique: true
   end
 
-  create_table "owns", id: :serial, force: :cascade do |t|
+  create_table "owns", force: :cascade do |t|
     t.integer "agent_id", null: false
     t.integer "item_id", null: false
     t.integer "position"
@@ -1090,7 +1105,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["item_id", "agent_id"], name: "index_owns_on_item_id_and_agent_id", unique: true
   end
 
-  create_table "participates", id: :serial, force: :cascade do |t|
+  create_table "participates", force: :cascade do |t|
     t.integer "agent_id", null: false
     t.integer "event_id", null: false
     t.integer "position"
@@ -1100,7 +1115,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["event_id"], name: "index_participates_on_event_id"
   end
 
-  create_table "picture_files", id: :serial, force: :cascade do |t|
+  create_table "picture_files", force: :cascade do |t|
     t.integer "picture_attachable_id"
     t.string "picture_attachable_type"
     t.text "title"
@@ -1118,7 +1133,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["picture_attachable_id", "picture_attachable_type"], name: "index_picture_files_on_picture_attachable_id_and_type"
   end
 
-  create_table "places", id: :serial, force: :cascade do |t|
+  create_table "places", force: :cascade do |t|
     t.string "term"
     t.text "city"
     t.integer "country_id"
@@ -1130,16 +1145,17 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["term"], name: "index_places_on_term"
   end
 
-  create_table "produce_types", id: :serial, force: :cascade do |t|
-    t.string "name"
+  create_table "produce_types", force: :cascade do |t|
+    t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_produce_types_on_lower_name", unique: true
   end
 
-  create_table "produces", id: :serial, force: :cascade do |t|
+  create_table "produces", force: :cascade do |t|
     t.integer "agent_id", null: false
     t.integer "manifestation_id", null: false
     t.integer "position"
@@ -1150,7 +1166,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["manifestation_id", "agent_id"], name: "index_produces_on_manifestation_id_and_agent_id", unique: true
   end
 
-  create_table "profiles", id: :serial, force: :cascade do |t|
+  create_table "profiles", force: :cascade do |t|
     t.integer "user_id"
     t.integer "user_group_id"
     t.integer "library_id"
@@ -1175,16 +1191,17 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_number"], name: "index_profiles_on_user_number", unique: true
   end
 
-  create_table "realize_types", id: :serial, force: :cascade do |t|
-    t.string "name"
+  create_table "realize_types", force: :cascade do |t|
+    t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_realize_types_on_lower_name", unique: true
   end
 
-  create_table "realizes", id: :serial, force: :cascade do |t|
+  create_table "realizes", force: :cascade do |t|
     t.integer "agent_id", null: false
     t.integer "expression_id", null: false
     t.integer "position"
@@ -1195,25 +1212,27 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["expression_id", "agent_id"], name: "index_realizes_on_expression_id_and_agent_id", unique: true
   end
 
-  create_table "request_status_types", id: :serial, force: :cascade do |t|
+  create_table "request_status_types", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_request_status_types_on_lower_name", unique: true
   end
 
-  create_table "request_types", id: :serial, force: :cascade do |t|
+  create_table "request_types", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_request_types_on_lower_name", unique: true
   end
 
-  create_table "reserve_stat_has_manifestations", id: :serial, force: :cascade do |t|
+  create_table "reserve_stat_has_manifestations", force: :cascade do |t|
     t.integer "manifestation_reserve_stat_id", null: false
     t.integer "manifestation_id", null: false
     t.integer "reserves_count"
@@ -1223,7 +1242,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["manifestation_reserve_stat_id"], name: "index_reserve_stat_has_manifestations_on_m_reserve_stat_id"
   end
 
-  create_table "reserve_stat_has_users", id: :serial, force: :cascade do |t|
+  create_table "reserve_stat_has_users", force: :cascade do |t|
     t.integer "user_reserve_stat_id", null: false
     t.integer "user_id", null: false
     t.integer "reserves_count"
@@ -1233,7 +1252,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_reserve_stat_id"], name: "index_reserve_stat_has_users_on_user_reserve_stat_id"
   end
 
-  create_table "reserve_transitions", id: :serial, force: :cascade do |t|
+  create_table "reserve_transitions", force: :cascade do |t|
     t.string "to_state"
     t.text "metadata", default: "{}"
     t.integer "sort_key"
@@ -1246,7 +1265,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["sort_key", "reserve_id"], name: "index_reserve_transitions_on_sort_key_and_reserve_id", unique: true
   end
 
-  create_table "reserves", id: :serial, force: :cascade do |t|
+  create_table "reserves", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "manifestation_id", null: false
     t.integer "item_id"
@@ -1268,7 +1287,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_id"], name: "index_reserves_on_user_id"
   end
 
-  create_table "resource_export_file_transitions", id: :serial, force: :cascade do |t|
+  create_table "resource_export_file_transitions", force: :cascade do |t|
     t.string "to_state"
     t.text "metadata", default: "{}"
     t.integer "sort_key"
@@ -1281,7 +1300,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["sort_key", "resource_export_file_id"], name: "index_resource_export_file_transitions_on_sort_key_and_file_id", unique: true
   end
 
-  create_table "resource_export_files", id: :serial, force: :cascade do |t|
+  create_table "resource_export_files", force: :cascade do |t|
     t.integer "user_id"
     t.string "resource_export_file_name"
     t.string "resource_export_content_type"
@@ -1292,7 +1311,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "resource_import_file_transitions", id: :serial, force: :cascade do |t|
+  create_table "resource_import_file_transitions", force: :cascade do |t|
     t.string "to_state"
     t.text "metadata", default: "{}"
     t.integer "sort_key"
@@ -1305,7 +1324,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["sort_key", "resource_import_file_id"], name: "index_resource_import_file_transitions_on_sort_key_and_file_id", unique: true
   end
 
-  create_table "resource_import_files", id: :serial, force: :cascade do |t|
+  create_table "resource_import_files", force: :cascade do |t|
     t.integer "parent_id"
     t.string "content_type"
     t.integer "size"
@@ -1327,7 +1346,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_id"], name: "index_resource_import_files_on_user_id"
   end
 
-  create_table "resource_import_results", id: :serial, force: :cascade do |t|
+  create_table "resource_import_results", force: :cascade do |t|
     t.integer "resource_import_file_id"
     t.integer "manifestation_id"
     t.integer "item_id"
@@ -1340,7 +1359,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["resource_import_file_id"], name: "index_resource_import_results_on_resource_import_file_id"
   end
 
-  create_table "roles", id: :serial, force: :cascade do |t|
+  create_table "roles", force: :cascade do |t|
     t.string "name", null: false
     t.string "display_name"
     t.text "note"
@@ -1348,9 +1367,10 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "score", default: 0, null: false
     t.integer "position"
+    t.index "lower((name)::text)", name: "index_roles_on_lower_name", unique: true
   end
 
-  create_table "search_engines", id: :serial, force: :cascade do |t|
+  create_table "search_engines", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.string "url", null: false
@@ -1364,13 +1384,13 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "series_statement_merge_lists", id: :serial, force: :cascade do |t|
+  create_table "series_statement_merge_lists", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "series_statement_merges", id: :serial, force: :cascade do |t|
+  create_table "series_statement_merges", force: :cascade do |t|
     t.integer "series_statement_id", null: false
     t.integer "series_statement_merge_list_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -1379,7 +1399,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["series_statement_merge_list_id"], name: "index_series_statement_merges_on_list_id"
   end
 
-  create_table "series_statements", id: :serial, force: :cascade do |t|
+  create_table "series_statements", force: :cascade do |t|
     t.text "original_title"
     t.text "numbering"
     t.text "title_subseries"
@@ -1403,7 +1423,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["series_statement_identifier"], name: "index_series_statements_on_series_statement_identifier"
   end
 
-  create_table "shelves", id: :serial, force: :cascade do |t|
+  create_table "shelves", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.text "note"
@@ -1413,28 +1433,31 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "closed", default: false, null: false
+    t.index "lower((name)::text)", name: "index_shelves_on_lower_name", unique: true
     t.index ["library_id"], name: "index_shelves_on_library_id"
   end
 
-  create_table "subject_heading_types", id: :serial, force: :cascade do |t|
+  create_table "subject_heading_types", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_subject_heading_types_on_lower_name", unique: true
   end
 
-  create_table "subject_types", id: :serial, force: :cascade do |t|
+  create_table "subject_types", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_subject_types_on_lower_name", unique: true
   end
 
-  create_table "subjects", id: :serial, force: :cascade do |t|
+  create_table "subjects", force: :cascade do |t|
     t.integer "parent_id"
     t.integer "use_term_id"
     t.string "term"
@@ -1457,7 +1480,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["use_term_id"], name: "index_subjects_on_use_term_id"
   end
 
-  create_table "subscribes", id: :serial, force: :cascade do |t|
+  create_table "subscribes", force: :cascade do |t|
     t.integer "subscription_id", null: false
     t.integer "work_id", null: false
     t.datetime "start_at", null: false
@@ -1468,7 +1491,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["work_id"], name: "index_subscribes_on_work_id"
   end
 
-  create_table "subscriptions", id: :serial, force: :cascade do |t|
+  create_table "subscriptions", force: :cascade do |t|
     t.text "title", null: false
     t.text "note"
     t.integer "user_id"
@@ -1480,7 +1503,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_id"], name: "index_subscriptions_on_user_id"
   end
 
-  create_table "taggings", id: :serial, force: :cascade do |t|
+  create_table "taggings", force: :cascade do |t|
     t.integer "tag_id"
     t.string "taggable_type"
     t.integer "taggable_id"
@@ -1499,24 +1522,25 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
   end
 
-  create_table "tags", id: :serial, force: :cascade do |t|
-    t.string "name"
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
     t.integer "taggings_count", default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
-  create_table "use_restrictions", id: :serial, force: :cascade do |t|
+  create_table "use_restrictions", force: :cascade do |t|
     t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_use_restrictions_on_lower_name", unique: true
   end
 
-  create_table "user_checkout_stat_transitions", id: :serial, force: :cascade do |t|
+  create_table "user_checkout_stat_transitions", force: :cascade do |t|
     t.string "to_state"
     t.text "metadata", default: "{}"
     t.integer "sort_key"
@@ -1529,7 +1553,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_checkout_stat_id"], name: "index_user_checkout_stat_transitions_on_user_checkout_stat_id"
   end
 
-  create_table "user_checkout_stats", id: :serial, force: :cascade do |t|
+  create_table "user_checkout_stats", force: :cascade do |t|
     t.datetime "start_date"
     t.datetime "end_date"
     t.text "note"
@@ -1541,7 +1565,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_id"], name: "index_user_checkout_stats_on_user_id"
   end
 
-  create_table "user_export_file_transitions", id: :serial, force: :cascade do |t|
+  create_table "user_export_file_transitions", force: :cascade do |t|
     t.string "to_state"
     t.text "metadata", default: "{}"
     t.integer "sort_key"
@@ -1555,7 +1579,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_export_file_id"], name: "index_user_export_file_transitions_on_user_export_file_id"
   end
 
-  create_table "user_export_files", id: :serial, force: :cascade do |t|
+  create_table "user_export_files", force: :cascade do |t|
     t.integer "user_id"
     t.string "user_export_file_name"
     t.string "user_export_content_type"
@@ -1567,7 +1591,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_id"], name: "index_user_export_files_on_user_id"
   end
 
-  create_table "user_group_has_checkout_types", id: :serial, force: :cascade do |t|
+  create_table "user_group_has_checkout_types", force: :cascade do |t|
     t.integer "user_group_id", null: false
     t.integer "checkout_type_id", null: false
     t.integer "checkout_limit", default: 0, null: false
@@ -1586,8 +1610,8 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_group_id"], name: "index_user_group_has_checkout_types_on_user_group_id"
   end
 
-  create_table "user_groups", id: :serial, force: :cascade do |t|
-    t.string "name"
+  create_table "user_groups", force: :cascade do |t|
+    t.string "name", null: false
     t.text "display_name"
     t.text "note"
     t.integer "position"
@@ -1598,9 +1622,10 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.integer "number_of_day_to_notify_overdue", default: 0, null: false
     t.integer "number_of_day_to_notify_due_date", default: 0, null: false
     t.integer "number_of_time_to_notify_overdue", default: 0, null: false
+    t.index "lower((name)::text)", name: "index_user_groups_on_lower_name", unique: true
   end
 
-  create_table "user_has_roles", id: :serial, force: :cascade do |t|
+  create_table "user_has_roles", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "role_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -1609,7 +1634,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_id"], name: "index_user_has_roles_on_user_id"
   end
 
-  create_table "user_import_file_transitions", id: :serial, force: :cascade do |t|
+  create_table "user_import_file_transitions", force: :cascade do |t|
     t.string "to_state"
     t.text "metadata", default: "{}"
     t.integer "sort_key"
@@ -1622,7 +1647,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_import_file_id"], name: "index_user_import_file_transitions_on_user_import_file_id"
   end
 
-  create_table "user_import_files", id: :serial, force: :cascade do |t|
+  create_table "user_import_files", force: :cascade do |t|
     t.integer "user_id"
     t.text "note"
     t.datetime "executed_at"
@@ -1641,7 +1666,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_id"], name: "index_user_import_files_on_user_id"
   end
 
-  create_table "user_import_results", id: :serial, force: :cascade do |t|
+  create_table "user_import_results", force: :cascade do |t|
     t.integer "user_import_file_id"
     t.integer "user_id"
     t.text "body"
@@ -1652,7 +1677,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_import_file_id"], name: "index_user_import_results_on_user_import_file_id"
   end
 
-  create_table "user_reserve_stat_transitions", id: :serial, force: :cascade do |t|
+  create_table "user_reserve_stat_transitions", force: :cascade do |t|
     t.string "to_state"
     t.text "metadata", default: "{}"
     t.integer "sort_key"
@@ -1665,7 +1690,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["user_reserve_stat_id"], name: "index_user_reserve_stat_transitions_on_user_reserve_stat_id"
   end
 
-  create_table "user_reserve_stats", id: :serial, force: :cascade do |t|
+  create_table "user_reserve_stats", force: :cascade do |t|
     t.datetime "start_date"
     t.datetime "end_date"
     t.text "note"
@@ -1697,7 +1722,7 @@ ActiveRecord::Schema.define(version: 2022_11_12_065100) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
-  create_table "withdraws", id: :serial, force: :cascade do |t|
+  create_table "withdraws", force: :cascade do |t|
     t.integer "basket_id"
     t.integer "item_id"
     t.integer "librarian_id"

--- a/spec/factories/accepts.rb
+++ b/spec/factories/accepts.rb
@@ -12,7 +12,7 @@ end
 #
 # Table name: accepts
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  basket_id    :integer
 #  item_id      :integer
 #  librarian_id :integer

--- a/spec/factories/agent_merge_lists.rb
+++ b/spec/factories/agent_merge_lists.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: agent_merge_lists
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/factories/agent_merges.rb
+++ b/spec/factories/agent_merges.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: agent_merges
 #
-#  id                  :integer          not null, primary key
+#  id                  :bigint           not null, primary key
 #  agent_id            :integer          not null
 #  agent_merge_list_id :integer          not null
 #  created_at          :datetime         not null

--- a/spec/factories/agent_relationship_types.rb
+++ b/spec/factories/agent_relationship_types.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: agent_relationship_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/factories/agent_relationships.rb
+++ b/spec/factories/agent_relationships.rb
@@ -10,7 +10,7 @@ end
 #
 # Table name: agent_relationships
 #
-#  id                         :integer          not null, primary key
+#  id                         :bigint           not null, primary key
 #  parent_id                  :integer
 #  child_id                   :integer
 #  agent_relationship_type_id :integer

--- a/spec/factories/agent_types.rb
+++ b/spec/factories/agent_types.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: agent_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/factories/agents.rb
+++ b/spec/factories/agents.rb
@@ -16,7 +16,7 @@ end
 #
 # Table name: agents
 #
-#  id                                  :integer          not null, primary key
+#  id                                  :bigint           not null, primary key
 #  last_name                           :string
 #  middle_name                         :string
 #  first_name                          :string

--- a/spec/factories/baskets.rb
+++ b/spec/factories/baskets.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: baskets
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  user_id      :integer
 #  note         :text
 #  lock_version :integer          default(0), not null

--- a/spec/factories/bookmark_stats.rb
+++ b/spec/factories/bookmark_stats.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: bookmark_stats
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  start_date   :datetime
 #  end_date     :datetime
 #  started_at   :datetime

--- a/spec/factories/bookmarks.rb
+++ b/spec/factories/bookmarks.rb
@@ -11,7 +11,7 @@ end
 #
 # Table name: bookmarks
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  user_id          :integer          not null
 #  manifestation_id :integer
 #  title            :text

--- a/spec/factories/bookstores.rb
+++ b/spec/factories/bookstores.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: bookstores
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  name             :text             not null
 #  zip_code         :string
 #  address          :text

--- a/spec/factories/budget_types.rb
+++ b/spec/factories/budget_types.rb
@@ -8,8 +8,8 @@ end
 #
 # Table name: budget_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/spec/factories/carrier_type_has_checkout_types.rb
+++ b/spec/factories/carrier_type_has_checkout_types.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: carrier_type_has_checkout_types
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  carrier_type_id  :integer          not null
 #  checkout_type_id :integer          not null
 #  note             :text

--- a/spec/factories/carrier_types.rb
+++ b/spec/factories/carrier_types.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: carrier_types
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  name                    :string           not null
 #  display_name            :text
 #  note                    :text

--- a/spec/factories/checkout_types.rb
+++ b/spec/factories/checkout_types.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: checkout_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/factories/checkouts.rb
+++ b/spec/factories/checkouts.rb
@@ -12,7 +12,7 @@ end
 #
 # Table name: checkouts
 #
-#  id                     :integer          not null, primary key
+#  id                     :bigint           not null, primary key
 #  user_id                :integer
 #  item_id                :integer          not null
 #  checkin_id             :integer

--- a/spec/factories/circulation_statuses.rb
+++ b/spec/factories/circulation_statuses.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: circulation_statuses
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/factories/classification_types.rb
+++ b/spec/factories/classification_types.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: classification_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/factories/classifications.rb
+++ b/spec/factories/classifications.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: classifications
 #
-#  id                     :integer          not null, primary key
+#  id                     :bigint           not null, primary key
 #  parent_id              :integer
 #  category               :string           not null
 #  note                   :text

--- a/spec/factories/content_types.rb
+++ b/spec/factories/content_types.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: content_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/factories/countries.rb
+++ b/spec/factories/countries.rb
@@ -11,7 +11,7 @@ end
 #
 # Table name: countries
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  alpha_2      :string

--- a/spec/factories/create_types.rb
+++ b/spec/factories/create_types.rb
@@ -12,8 +12,8 @@ end
 #
 # Table name: create_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/spec/factories/creates.rb
+++ b/spec/factories/creates.rb
@@ -10,7 +10,7 @@ end
 #
 # Table name: creates
 #
-#  id             :integer          not null, primary key
+#  id             :bigint           not null, primary key
 #  agent_id       :integer          not null
 #  work_id        :integer          not null
 #  position       :integer

--- a/spec/factories/demands.rb
+++ b/spec/factories/demands.rb
@@ -10,7 +10,7 @@ end
 #
 # Table name: demands
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  user_id    :integer
 #  item_id    :integer
 #  message_id :integer

--- a/spec/factories/donates.rb
+++ b/spec/factories/donates.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: donates
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  agent_id   :integer          not null
 #  item_id    :integer          not null
 #  created_at :datetime         not null

--- a/spec/factories/event_categories.rb
+++ b/spec/factories/event_categories.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: event_categories
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -12,10 +12,10 @@ end
 #
 # Table name: events
 #
-#  id                :integer          not null, primary key
+#  id                :bigint           not null, primary key
 #  library_id        :integer          not null
 #  event_category_id :integer          not null
-#  name              :string
+#  name              :string           not null
 #  note              :text
 #  start_at          :datetime
 #  end_at            :datetime

--- a/spec/factories/form_of_works.rb
+++ b/spec/factories/form_of_works.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: form_of_works
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/factories/frequencies.rb
+++ b/spec/factories/frequencies.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: frequencies
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/factories/identifier_types.rb
+++ b/spec/factories/identifier_types.rb
@@ -8,8 +8,8 @@ end
 #
 # Table name: identifier_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/spec/factories/identifiers.rb
+++ b/spec/factories/identifiers.rb
@@ -10,7 +10,7 @@ end
 #
 # Table name: identifiers
 #
-#  id                 :integer          not null, primary key
+#  id                 :bigint           not null, primary key
 #  body               :string           not null
 #  identifier_type_id :integer          not null
 #  manifestation_id   :integer

--- a/spec/factories/import_requests.rb
+++ b/spec/factories/import_requests.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: import_requests
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  isbn             :string
 #  manifestation_id :integer
 #  user_id          :integer

--- a/spec/factories/item_has_use_restrictions.rb
+++ b/spec/factories/item_has_use_restrictions.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: item_has_use_restrictions
 #
-#  id                 :integer          not null, primary key
+#  id                 :bigint           not null, primary key
 #  item_id            :integer          not null
 #  use_restriction_id :integer          not null
 #  created_at         :datetime         not null

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -15,7 +15,7 @@ end
 #
 # Table name: items
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  call_number             :string
 #  item_identifier         :string
 #  created_at              :datetime         not null

--- a/spec/factories/languages.rb
+++ b/spec/factories/languages.rb
@@ -11,7 +11,7 @@ end
 #
 # Table name: languages
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  native_name  :string
 #  display_name :text

--- a/spec/factories/libraries.rb
+++ b/spec/factories/libraries.rb
@@ -16,7 +16,7 @@ end
 #
 # Table name: libraries
 #
-#  id                    :integer          not null, primary key
+#  id                    :bigint           not null, primary key
 #  name                  :string           not null
 #  display_name          :text
 #  short_display_name    :string           not null

--- a/spec/factories/licenses.rb
+++ b/spec/factories/licenses.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: licenses
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :string
 #  note         :text

--- a/spec/factories/manifestation_checkout_stats.rb
+++ b/spec/factories/manifestation_checkout_stats.rb
@@ -10,7 +10,7 @@ end
 #
 # Table name: manifestation_checkout_stats
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text

--- a/spec/factories/manifestation_relationship_types.rb
+++ b/spec/factories/manifestation_relationship_types.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: manifestation_relationship_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/factories/manifestation_relationships.rb
+++ b/spec/factories/manifestation_relationships.rb
@@ -10,7 +10,7 @@ end
 #
 # Table name: manifestation_relationships
 #
-#  id                                 :integer          not null, primary key
+#  id                                 :bigint           not null, primary key
 #  parent_id                          :integer
 #  child_id                           :integer
 #  manifestation_relationship_type_id :integer

--- a/spec/factories/manifestation_reserve_stats.rb
+++ b/spec/factories/manifestation_reserve_stats.rb
@@ -10,7 +10,7 @@ end
 #
 # Table name: manifestation_reserve_stats
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text

--- a/spec/factories/manifestations.rb
+++ b/spec/factories/manifestations.rb
@@ -17,7 +17,7 @@ end
 #
 # Table name: manifestations
 #
-#  id                              :integer          not null, primary key
+#  id                              :bigint           not null, primary key
 #  original_title                  :text             not null
 #  title_alternative               :text
 #  title_transcription             :text

--- a/spec/factories/medium_of_performances.rb
+++ b/spec/factories/medium_of_performances.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: medium_of_performances
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/factories/news_feeds.rb
+++ b/spec/factories/news_feeds.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: news_feeds
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  library_group_id :integer          default(1), not null
 #  title            :string
 #  url              :string

--- a/spec/factories/news_posts.rb
+++ b/spec/factories/news_posts.rb
@@ -10,7 +10,7 @@ end
 #
 # Table name: news_posts
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  title            :text
 #  body             :text
 #  user_id          :integer

--- a/spec/factories/owns.rb
+++ b/spec/factories/owns.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: owns
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  agent_id   :integer          not null
 #  item_id    :integer          not null
 #  position   :integer

--- a/spec/factories/participates.rb
+++ b/spec/factories/participates.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: participates
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  agent_id   :integer          not null
 #  event_id   :integer          not null
 #  position   :integer

--- a/spec/factories/places.rb
+++ b/spec/factories/places.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: places
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  term       :string
 #  city       :text
 #  country_id :integer

--- a/spec/factories/produce_types.rb
+++ b/spec/factories/produce_types.rb
@@ -12,8 +12,8 @@ end
 #
 # Table name: produce_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/spec/factories/produces.rb
+++ b/spec/factories/produces.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: produces
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  agent_id         :integer          not null
 #  manifestation_id :integer          not null
 #  position         :integer

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -20,7 +20,7 @@ end
 #
 # Table name: profiles
 #
-#  id                       :integer          not null, primary key
+#  id                       :bigint           not null, primary key
 #  user_id                  :integer
 #  user_group_id            :integer
 #  library_id               :integer

--- a/spec/factories/realize_types.rb
+++ b/spec/factories/realize_types.rb
@@ -12,8 +12,8 @@ end
 #
 # Table name: realize_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/spec/factories/realizes.rb
+++ b/spec/factories/realizes.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: realizes
 #
-#  id              :integer          not null, primary key
+#  id              :bigint           not null, primary key
 #  agent_id        :integer          not null
 #  expression_id   :integer          not null
 #  position        :integer

--- a/spec/factories/request_status_types.rb
+++ b/spec/factories/request_status_types.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: request_status_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/factories/request_types.rb
+++ b/spec/factories/request_types.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: request_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/factories/reserves.rb
+++ b/spec/factories/reserves.rb
@@ -18,7 +18,7 @@ end
 #
 # Table name: reserves
 #
-#  id                           :integer          not null, primary key
+#  id                           :bigint           not null, primary key
 #  user_id                      :integer          not null
 #  manifestation_id             :integer          not null
 #  item_id                      :integer

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -12,7 +12,7 @@ end
 #
 # Table name: roles
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :string
 #  note         :text

--- a/spec/factories/search_engines.rb
+++ b/spec/factories/search_engines.rb
@@ -12,7 +12,7 @@ end
 #
 # Table name: search_engines
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  name             :string           not null
 #  display_name     :text
 #  url              :string           not null

--- a/spec/factories/series_statement_merge_lists.rb
+++ b/spec/factories/series_statement_merge_lists.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: series_statement_merge_lists
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/factories/series_statement_merges.rb
+++ b/spec/factories/series_statement_merges.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: series_statement_merges
 #
-#  id                             :integer          not null, primary key
+#  id                             :bigint           not null, primary key
 #  series_statement_id            :integer          not null
 #  series_statement_merge_list_id :integer          not null
 #  created_at                     :datetime         not null

--- a/spec/factories/series_statements.rb
+++ b/spec/factories/series_statements.rb
@@ -15,7 +15,7 @@ end
 #
 # Table name: series_statements
 #
-#  id                                 :integer          not null, primary key
+#  id                                 :bigint           not null, primary key
 #  original_title                     :text
 #  numbering                          :text
 #  title_subseries                    :text

--- a/spec/factories/shelves.rb
+++ b/spec/factories/shelves.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: shelves
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/factories/subject_heading_types.rb
+++ b/spec/factories/subject_heading_types.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: subject_heading_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/factories/subject_types.rb
+++ b/spec/factories/subject_types.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: subject_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -10,7 +10,7 @@ end
 #
 # Table name: subjects
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  parent_id               :integer
 #  use_term_id             :integer
 #  term                    :string

--- a/spec/factories/subscribes.rb
+++ b/spec/factories/subscribes.rb
@@ -11,7 +11,7 @@ end
 #
 # Table name: subscribes
 #
-#  id              :integer          not null, primary key
+#  id              :bigint           not null, primary key
 #  subscription_id :integer          not null
 #  work_id         :integer          not null
 #  start_at        :datetime         not null

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: subscriptions
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  title            :text             not null
 #  note             :text
 #  user_id          :integer

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -8,8 +8,8 @@ end
 #
 # Table name: tags
 #
-#  id             :integer          not null, primary key
-#  name           :string
+#  id             :bigint           not null, primary key
+#  name           :string           not null
 #  taggings_count :integer          default(0)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null

--- a/spec/factories/use_restrictions.rb
+++ b/spec/factories/use_restrictions.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: use_restrictions
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/factories/user_checkout_stats.rb
+++ b/spec/factories/user_checkout_stats.rb
@@ -10,7 +10,7 @@ end
 #
 # Table name: user_checkout_stats
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text

--- a/spec/factories/user_group_has_checkout_types.rb
+++ b/spec/factories/user_group_has_checkout_types.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: user_group_has_checkout_types
 #
-#  id                              :integer          not null, primary key
+#  id                              :bigint           not null, primary key
 #  user_group_id                   :integer          not null
 #  checkout_type_id                :integer          not null
 #  checkout_limit                  :integer          default(0), not null

--- a/spec/factories/user_groups.rb
+++ b/spec/factories/user_groups.rb
@@ -8,8 +8,8 @@ end
 #
 # Table name: user_groups
 #
-#  id                               :integer          not null, primary key
-#  name                             :string
+#  id                               :bigint           not null, primary key
+#  name                             :string           not null
 #  display_name                     :text
 #  note                             :text
 #  position                         :integer

--- a/spec/factories/user_reserve_stats.rb
+++ b/spec/factories/user_reserve_stats.rb
@@ -10,7 +10,7 @@ end
 #
 # Table name: user_reserve_stats
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text

--- a/spec/factories/withdraws.rb
+++ b/spec/factories/withdraws.rb
@@ -12,7 +12,7 @@ end
 #
 # Table name: withdraws
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  basket_id    :integer
 #  item_id      :integer
 #  librarian_id :integer

--- a/spec/fixtures/accepts.yml
+++ b/spec/fixtures/accepts.yml
@@ -12,7 +12,7 @@ two:
 #
 # Table name: accepts
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  basket_id    :integer
 #  item_id      :integer
 #  librarian_id :integer

--- a/spec/fixtures/agent_import_files.yml
+++ b/spec/fixtures/agent_import_files.yml
@@ -23,7 +23,7 @@ agent_import_file_00003:
 #
 # Table name: agent_import_files
 #
-#  id                        :integer          not null, primary key
+#  id                        :bigint           not null, primary key
 #  parent_id                 :integer
 #  content_type              :string
 #  size                      :integer

--- a/spec/fixtures/agent_import_results.yml
+++ b/spec/fixtures/agent_import_results.yml
@@ -16,7 +16,7 @@ two:
 #
 # Table name: agent_import_results
 #
-#  id                   :integer          not null, primary key
+#  id                   :bigint           not null, primary key
 #  agent_import_file_id :integer
 #  agent_id             :integer
 #  body                 :text

--- a/spec/fixtures/agent_merge_lists.yml
+++ b/spec/fixtures/agent_merge_lists.yml
@@ -19,7 +19,7 @@ agent_merge_list_00003:
 #
 # Table name: agent_merge_lists
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/fixtures/agent_merges.yml
+++ b/spec/fixtures/agent_merges.yml
@@ -22,7 +22,7 @@ agent_merge_00003:
 #
 # Table name: agent_merges
 #
-#  id                  :integer          not null, primary key
+#  id                  :bigint           not null, primary key
 #  agent_id            :integer          not null
 #  agent_merge_list_id :integer          not null
 #  created_at          :datetime         not null

--- a/spec/fixtures/agent_relationship_types.yml
+++ b/spec/fixtures/agent_relationship_types.yml
@@ -23,7 +23,7 @@ agent_relationship_type_00003:
 #
 # Table name: agent_relationship_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/fixtures/agent_relationships.yml
+++ b/spec/fixtures/agent_relationships.yml
@@ -14,7 +14,7 @@ two:
 #
 # Table name: agent_relationships
 #
-#  id                         :integer          not null, primary key
+#  id                         :bigint           not null, primary key
 #  parent_id                  :integer
 #  child_id                   :integer
 #  agent_relationship_type_id :integer

--- a/spec/fixtures/agent_types.yml
+++ b/spec/fixtures/agent_types.yml
@@ -24,7 +24,7 @@ agent_type_00003:
 #
 # Table name: agent_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/fixtures/agents.yml
+++ b/spec/fixtures/agents.yml
@@ -276,7 +276,7 @@ agent_00202:
 #
 # Table name: agents
 #
-#  id                                  :integer          not null, primary key
+#  id                                  :bigint           not null, primary key
 #  last_name                           :string
 #  middle_name                         :string
 #  first_name                          :string

--- a/spec/fixtures/baskets.yml
+++ b/spec/fixtures/baskets.yml
@@ -70,7 +70,7 @@ basket_00011:
 #
 # Table name: baskets
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  user_id      :integer
 #  note         :text
 #  lock_version :integer          default(0), not null

--- a/spec/fixtures/bookmark_stat_has_manifestations.yml
+++ b/spec/fixtures/bookmark_stat_has_manifestations.yml
@@ -14,7 +14,7 @@ two:
 #
 # Table name: bookmark_stat_has_manifestations
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  bookmark_stat_id :integer          not null
 #  manifestation_id :integer          not null
 #  bookmarks_count  :integer

--- a/spec/fixtures/bookmark_stats.yml
+++ b/spec/fixtures/bookmark_stats.yml
@@ -16,7 +16,7 @@ bookmark_stat_00002:
 #
 # Table name: bookmark_stats
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  start_date   :datetime
 #  end_date     :datetime
 #  started_at   :datetime

--- a/spec/fixtures/bookmarks.yml
+++ b/spec/fixtures/bookmarks.yml
@@ -44,7 +44,7 @@ bookmark_00005:
 #
 # Table name: bookmarks
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  user_id          :integer          not null
 #  manifestation_id :integer
 #  title            :text

--- a/spec/fixtures/bookstores.yml
+++ b/spec/fixtures/bookstores.yml
@@ -74,7 +74,7 @@ bookstore_00007:
 #
 # Table name: bookstores
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  name             :text             not null
 #  zip_code         :string
 #  address          :text

--- a/spec/fixtures/budget_types.yml
+++ b/spec/fixtures/budget_types.yml
@@ -18,8 +18,8 @@ donation:
 #
 # Table name: budget_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/spec/fixtures/carrier_type_has_checkout_types.yml
+++ b/spec/fixtures/carrier_type_has_checkout_types.yml
@@ -20,7 +20,7 @@ carrier_type_has_checkout_type_00003:
 #
 # Table name: carrier_type_has_checkout_types
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  carrier_type_id  :integer          not null
 #  checkout_type_id :integer          not null
 #  note             :text

--- a/spec/fixtures/carrier_types.yml
+++ b/spec/fixtures/carrier_types.yml
@@ -36,7 +36,7 @@ carrier_type_00004:
 #
 # Table name: carrier_types
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  name                    :string           not null
 #  display_name            :text
 #  note                    :text

--- a/spec/fixtures/checked_items.yml
+++ b/spec/fixtures/checked_items.yml
@@ -24,7 +24,7 @@ checked_item_00004:
 #
 # Table name: checked_items
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  item_id      :integer          not null
 #  basket_id    :integer          not null
 #  librarian_id :integer

--- a/spec/fixtures/checkins.yml
+++ b/spec/fixtures/checkins.yml
@@ -44,7 +44,7 @@ checkin_00005:
 #
 # Table name: checkins
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  item_id      :integer          not null
 #  librarian_id :integer
 #  basket_id    :integer

--- a/spec/fixtures/checkout_stat_has_manifestations.yml
+++ b/spec/fixtures/checkout_stat_has_manifestations.yml
@@ -14,7 +14,7 @@ two:
 #
 # Table name: checkout_stat_has_manifestations
 #
-#  id                             :integer          not null, primary key
+#  id                             :bigint           not null, primary key
 #  manifestation_checkout_stat_id :integer          not null
 #  manifestation_id               :integer          not null
 #  checkouts_count                :integer

--- a/spec/fixtures/checkout_stat_has_users.yml
+++ b/spec/fixtures/checkout_stat_has_users.yml
@@ -14,7 +14,7 @@ two:
 #
 # Table name: checkout_stat_has_users
 #
-#  id                    :integer          not null, primary key
+#  id                    :bigint           not null, primary key
 #  user_checkout_stat_id :integer          not null
 #  user_id               :integer          not null
 #  checkouts_count       :integer          default(0), not null

--- a/spec/fixtures/checkout_types.yml
+++ b/spec/fixtures/checkout_types.yml
@@ -23,7 +23,7 @@ checkout_type_00003:
 #
 # Table name: checkout_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/fixtures/checkouts.yml
+++ b/spec/fixtures/checkouts.yml
@@ -160,7 +160,7 @@ checkout_00014:
 #
 # Table name: checkouts
 #
-#  id                     :integer          not null, primary key
+#  id                     :bigint           not null, primary key
 #  user_id                :integer
 #  item_id                :integer          not null
 #  checkin_id             :integer

--- a/spec/fixtures/circulation_statuses.yml
+++ b/spec/fixtures/circulation_statuses.yml
@@ -109,7 +109,7 @@ circulation_status_00016:
 #
 # Table name: circulation_statuses
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/fixtures/classification_types.yml
+++ b/spec/fixtures/classification_types.yml
@@ -52,7 +52,7 @@ classification_type_00006:
 #
 # Table name: classification_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/fixtures/classifications.yml
+++ b/spec/fixtures/classifications.yml
@@ -105,7 +105,7 @@ classification_00005:
 #
 # Table name: classifications
 #
-#  id                     :integer          not null, primary key
+#  id                     :bigint           not null, primary key
 #  parent_id              :integer
 #  category               :string           not null
 #  note                   :text

--- a/spec/fixtures/colors.yml
+++ b/spec/fixtures/colors.yml
@@ -28,7 +28,7 @@ color_00004:
 #
 # Table name: colors
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  library_group_id :integer
 #  property         :string
 #  code             :string

--- a/spec/fixtures/content_types.yml
+++ b/spec/fixtures/content_types.yml
@@ -88,7 +88,7 @@ content_type_00012:
 #
 # Table name: content_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/fixtures/countries.yml
+++ b/spec/fixtures/countries.yml
@@ -2047,7 +2047,7 @@ country_00170:
 #
 # Table name: countries
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  alpha_2      :string

--- a/spec/fixtures/create_types.yml
+++ b/spec/fixtures/create_types.yml
@@ -36,8 +36,8 @@ illustrator:
 #
 # Table name: create_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/spec/fixtures/creates.yml
+++ b/spec/fixtures/creates.yml
@@ -55,7 +55,7 @@ create_00104:
 #
 # Table name: creates
 #
-#  id             :integer          not null, primary key
+#  id             :bigint           not null, primary key
 #  agent_id       :integer          not null
 #  work_id        :integer          not null
 #  position       :integer

--- a/spec/fixtures/demands.yml
+++ b/spec/fixtures/demands.yml
@@ -14,7 +14,7 @@ two:
 #
 # Table name: demands
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  user_id    :integer
 #  item_id    :integer
 #  message_id :integer

--- a/spec/fixtures/donates.yml
+++ b/spec/fixtures/donates.yml
@@ -22,7 +22,7 @@ donate_00003:
 #
 # Table name: donates
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  agent_id   :integer          not null
 #  item_id    :integer          not null
 #  created_at :datetime         not null

--- a/spec/fixtures/event_categories.yml
+++ b/spec/fixtures/event_categories.yml
@@ -44,7 +44,7 @@ event_category_00001:
 #
 # Table name: event_categories
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/fixtures/event_export_files.yml
+++ b/spec/fixtures/event_export_files.yml
@@ -14,7 +14,7 @@ event_export_file_00003:
 #
 # Table name: event_export_files
 #
-#  id                        :integer          not null, primary key
+#  id                        :bigint           not null, primary key
 #  user_id                   :integer
 #  event_export_file_name    :string
 #  event_export_content_type :string

--- a/spec/fixtures/event_import_files.yml
+++ b/spec/fixtures/event_import_files.yml
@@ -23,7 +23,7 @@ event_import_file_00003:
 #
 # Table name: event_import_files
 #
-#  id                        :integer          not null, primary key
+#  id                        :bigint           not null, primary key
 #  parent_id                 :integer
 #  content_type              :string
 #  size                      :integer

--- a/spec/fixtures/event_import_results.yml
+++ b/spec/fixtures/event_import_results.yml
@@ -16,7 +16,7 @@ two:
 #
 # Table name: event_import_results
 #
-#  id                   :integer          not null, primary key
+#  id                   :bigint           not null, primary key
 #  event_import_file_id :integer
 #  event_id             :integer
 #  body                 :text

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -92,10 +92,10 @@ event_00008:
 #
 # Table name: events
 #
-#  id                :integer          not null, primary key
+#  id                :bigint           not null, primary key
 #  library_id        :integer          not null
 #  event_category_id :integer          not null
-#  name              :string
+#  name              :string           not null
 #  note              :text
 #  start_at          :datetime
 #  end_at            :datetime

--- a/spec/fixtures/form_of_works.yml
+++ b/spec/fixtures/form_of_works.yml
@@ -28,7 +28,7 @@ form_of_work_00003:
 #
 # Table name: form_of_works
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/fixtures/frequencies.yml
+++ b/spec/fixtures/frequencies.yml
@@ -58,7 +58,7 @@ frequency_00009:
 #
 # Table name: frequencies
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/fixtures/identifier_types.yml
+++ b/spec/fixtures/identifier_types.yml
@@ -60,8 +60,8 @@ identifier_type_00007:
 #
 # Table name: identifier_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/spec/fixtures/identifiers.yml
+++ b/spec/fixtures/identifiers.yml
@@ -123,7 +123,7 @@ identifier_00004a:
 #
 # Table name: identifiers
 #
-#  id                 :integer          not null, primary key
+#  id                 :bigint           not null, primary key
 #  body               :string           not null
 #  identifier_type_id :integer          not null
 #  manifestation_id   :integer

--- a/spec/fixtures/import_requests.yml
+++ b/spec/fixtures/import_requests.yml
@@ -14,7 +14,7 @@ two:
 #
 # Table name: import_requests
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  isbn             :string
 #  manifestation_id :integer
 #  user_id          :integer

--- a/spec/fixtures/inventories.yml
+++ b/spec/fixtures/inventories.yml
@@ -16,7 +16,7 @@ inventory_00002:
 #
 # Table name: inventories
 #
-#  id                 :integer          not null, primary key
+#  id                 :bigint           not null, primary key
 #  item_id            :integer
 #  inventory_file_id  :integer
 #  note               :text

--- a/spec/fixtures/inventory_files.yml
+++ b/spec/fixtures/inventory_files.yml
@@ -23,7 +23,7 @@ inventory_file_00003:
 #
 # Table name: inventory_files
 #
-#  id                     :integer          not null, primary key
+#  id                     :bigint           not null, primary key
 #  filename               :string
 #  content_type           :string
 #  size                   :integer

--- a/spec/fixtures/item_has_use_restrictions.yml
+++ b/spec/fixtures/item_has_use_restrictions.yml
@@ -70,7 +70,7 @@ item_has_use_restriction_00011:
 #
 # Table name: item_has_use_restrictions
 #
-#  id                 :integer          not null, primary key
+#  id                 :bigint           not null, primary key
 #  item_id            :integer          not null
 #  use_restriction_id :integer          not null
 #  created_at         :datetime         not null

--- a/spec/fixtures/items.yml
+++ b/spec/fixtures/items.yml
@@ -292,7 +292,7 @@ item_00026:
 #
 # Table name: items
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  call_number             :string
 #  item_identifier         :string
 #  created_at              :datetime         not null

--- a/spec/fixtures/languages.yml
+++ b/spec/fixtures/languages.yml
@@ -1886,7 +1886,7 @@ language_00140:
 #
 # Table name: languages
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  native_name  :string
 #  display_name :text

--- a/spec/fixtures/libraries.yml
+++ b/spec/fixtures/libraries.yml
@@ -73,7 +73,7 @@ library_00004:
 #
 # Table name: libraries
 #
-#  id                    :integer          not null, primary key
+#  id                    :bigint           not null, primary key
 #  name                  :string           not null
 #  display_name          :text
 #  short_display_name    :string           not null

--- a/spec/fixtures/library_groups.yml
+++ b/spec/fixtures/library_groups.yml
@@ -17,7 +17,7 @@ one:
 #
 # Table name: library_groups
 #
-#  id                            :integer          not null, primary key
+#  id                            :bigint           not null, primary key
 #  name                          :string           not null
 #  display_name                  :text
 #  short_name                    :string           not null

--- a/spec/fixtures/licenses.yml
+++ b/spec/fixtures/licenses.yml
@@ -18,7 +18,7 @@ two:
 #
 # Table name: licenses
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :string
 #  note         :text

--- a/spec/fixtures/manifestation_checkout_stats.yml
+++ b/spec/fixtures/manifestation_checkout_stats.yml
@@ -18,7 +18,7 @@ two:
 #
 # Table name: manifestation_checkout_stats
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text

--- a/spec/fixtures/manifestation_relationship_types.yml
+++ b/spec/fixtures/manifestation_relationship_types.yml
@@ -18,7 +18,7 @@ two:
 #
 # Table name: manifestation_relationship_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/fixtures/manifestation_relationships.yml
+++ b/spec/fixtures/manifestation_relationships.yml
@@ -19,7 +19,7 @@ serial:
 #
 # Table name: manifestation_relationships
 #
-#  id                                 :integer          not null, primary key
+#  id                                 :bigint           not null, primary key
 #  parent_id                          :integer
 #  child_id                           :integer
 #  manifestation_relationship_type_id :integer

--- a/spec/fixtures/manifestation_reserve_stats.yml
+++ b/spec/fixtures/manifestation_reserve_stats.yml
@@ -18,7 +18,7 @@ two:
 #
 # Table name: manifestation_reserve_stats
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text

--- a/spec/fixtures/manifestations.yml
+++ b/spec/fixtures/manifestations.yml
@@ -1839,7 +1839,7 @@ manifestation_00218:
 #
 # Table name: manifestations
 #
-#  id                              :integer          not null, primary key
+#  id                              :bigint           not null, primary key
 #  original_title                  :text             not null
 #  title_alternative               :text
 #  title_transcription             :text

--- a/spec/fixtures/medium_of_performances.yml
+++ b/spec/fixtures/medium_of_performances.yml
@@ -18,7 +18,7 @@ two:
 #
 # Table name: medium_of_performances
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/fixtures/news_feeds.yml
+++ b/spec/fixtures/news_feeds.yml
@@ -14,7 +14,7 @@ news_feed_00002:
 #
 # Table name: news_feeds
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  library_group_id :integer          default(1), not null
 #  title            :string
 #  url              :string

--- a/spec/fixtures/news_posts.yml
+++ b/spec/fixtures/news_posts.yml
@@ -16,7 +16,7 @@ news_post_00002:
 #
 # Table name: news_posts
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  title            :text
 #  body             :text
 #  user_id          :integer

--- a/spec/fixtures/nii_types.yml
+++ b/spec/fixtures/nii_types.yml
@@ -81,7 +81,7 @@ nii_type_00013:
 #
 # Table name: nii_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/fixtures/owns.yml
+++ b/spec/fixtures/owns.yml
@@ -16,7 +16,7 @@ own_00002:
 #
 # Table name: owns
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  agent_id   :integer          not null
 #  item_id    :integer          not null
 #  position   :integer

--- a/spec/fixtures/picture_files.yml
+++ b/spec/fixtures/picture_files.yml
@@ -44,7 +44,7 @@ picture_file_00004:
 #
 # Table name: picture_files
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  picture_attachable_id   :integer
 #  picture_attachable_type :string
 #  title                   :text

--- a/spec/fixtures/produce_types.yml
+++ b/spec/fixtures/produce_types.yml
@@ -20,8 +20,8 @@ seller:
 #
 # Table name: produce_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/spec/fixtures/produces.yml
+++ b/spec/fixtures/produces.yml
@@ -139,7 +139,7 @@ produce_00202:
 #
 # Table name: produces
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  agent_id         :integer          not null
 #  manifestation_id :integer          not null
 #  position         :integer

--- a/spec/fixtures/profiles.yml
+++ b/spec/fixtures/profiles.yml
@@ -87,7 +87,7 @@ profile_user4:
 #
 # Table name: profiles
 #
-#  id                       :integer          not null, primary key
+#  id                       :bigint           not null, primary key
 #  user_id                  :integer
 #  user_group_id            :integer
 #  library_id               :integer

--- a/spec/fixtures/realize_types.yml
+++ b/spec/fixtures/realize_types.yml
@@ -28,8 +28,8 @@ illustrator:
 #
 # Table name: realize_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/spec/fixtures/realizes.yml
+++ b/spec/fixtures/realizes.yml
@@ -76,7 +76,7 @@ realize_00010:
 #
 # Table name: realizes
 #
-#  id              :integer          not null, primary key
+#  id              :bigint           not null, primary key
 #  agent_id        :integer          not null
 #  expression_id   :integer          not null
 #  position        :integer

--- a/spec/fixtures/request_status_types.yml
+++ b/spec/fixtures/request_status_types.yml
@@ -52,7 +52,7 @@ request_status_type_00006:
 #
 # Table name: request_status_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/fixtures/request_types.yml
+++ b/spec/fixtures/request_types.yml
@@ -44,7 +44,7 @@ request_type_00004:
 #
 # Table name: request_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/fixtures/reserve_stat_has_manifestations.yml
+++ b/spec/fixtures/reserve_stat_has_manifestations.yml
@@ -14,7 +14,7 @@ two:
 #
 # Table name: reserve_stat_has_manifestations
 #
-#  id                            :integer          not null, primary key
+#  id                            :bigint           not null, primary key
 #  manifestation_reserve_stat_id :integer          not null
 #  manifestation_id              :integer          not null
 #  reserves_count                :integer

--- a/spec/fixtures/reserve_stat_has_users.yml
+++ b/spec/fixtures/reserve_stat_has_users.yml
@@ -14,7 +14,7 @@ two:
 #
 # Table name: reserve_stat_has_users
 #
-#  id                   :integer          not null, primary key
+#  id                   :bigint           not null, primary key
 #  user_reserve_stat_id :integer          not null
 #  user_id              :integer          not null
 #  reserves_count       :integer

--- a/spec/fixtures/reserve_transitions.yml
+++ b/spec/fixtures/reserve_transitions.yml
@@ -93,7 +93,7 @@ reserve_transition_00015:
 #
 # Table name: reserve_transitions
 #
-#  id          :integer          not null, primary key
+#  id          :bigint           not null, primary key
 #  to_state    :string
 #  metadata    :text             default({})
 #  sort_key    :integer

--- a/spec/fixtures/reserves.yml
+++ b/spec/fixtures/reserves.yml
@@ -143,7 +143,7 @@ reserve_00015:
 #
 # Table name: reserves
 #
-#  id                           :integer          not null, primary key
+#  id                           :bigint           not null, primary key
 #  user_id                      :integer          not null
 #  manifestation_id             :integer          not null
 #  item_id                      :integer

--- a/spec/fixtures/resource_export_files.yml
+++ b/spec/fixtures/resource_export_files.yml
@@ -14,7 +14,7 @@ resource_export_file_00003:
 #
 # Table name: resource_export_files
 #
-#  id                           :integer          not null, primary key
+#  id                           :bigint           not null, primary key
 #  user_id                      :integer
 #  resource_export_file_name    :string
 #  resource_export_content_type :string

--- a/spec/fixtures/resource_import_files.yml
+++ b/spec/fixtures/resource_import_files.yml
@@ -24,7 +24,7 @@ resource_import_file_00003:
 #
 # Table name: resource_import_files
 #
-#  id                           :integer          not null, primary key
+#  id                           :bigint           not null, primary key
 #  parent_id                    :integer
 #  content_type                 :string
 #  size                         :integer

--- a/spec/fixtures/resource_import_results.yml
+++ b/spec/fixtures/resource_import_results.yml
@@ -18,7 +18,7 @@ two:
 #
 # Table name: resource_import_results
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  resource_import_file_id :integer
 #  manifestation_id        :integer
 #  item_id                 :integer

--- a/spec/fixtures/roles.yml
+++ b/spec/fixtures/roles.yml
@@ -24,7 +24,7 @@ role_00004:
 #
 # Table name: roles
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :string
 #  note         :text

--- a/spec/fixtures/search_engines.yml
+++ b/spec/fixtures/search_engines.yml
@@ -25,7 +25,7 @@ search_engine_00002:
 #
 # Table name: search_engines
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  name             :string           not null
 #  display_name     :text
 #  url              :string           not null

--- a/spec/fixtures/series_statement_merge_lists.yml
+++ b/spec/fixtures/series_statement_merge_lists.yml
@@ -19,7 +19,7 @@ series_statement_merge_list_00003:
 #
 # Table name: series_statement_merge_lists
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/fixtures/series_statement_merges.yml
+++ b/spec/fixtures/series_statement_merges.yml
@@ -22,7 +22,7 @@ series_statement_merge_00003:
 #
 # Table name: series_statement_merges
 #
-#  id                             :integer          not null, primary key
+#  id                             :bigint           not null, primary key
 #  series_statement_id            :integer          not null
 #  series_statement_merge_list_id :integer          not null
 #  created_at                     :datetime         not null

--- a/spec/fixtures/series_statements.yml
+++ b/spec/fixtures/series_statements.yml
@@ -33,7 +33,7 @@ five:
 #
 # Table name: series_statements
 #
-#  id                                 :integer          not null, primary key
+#  id                                 :bigint           not null, primary key
 #  original_title                     :text
 #  numbering                          :text
 #  title_subseries                    :text

--- a/spec/fixtures/shelves.yml
+++ b/spec/fixtures/shelves.yml
@@ -32,7 +32,7 @@ shelf_00004:
 #
 # Table name: shelves
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/fixtures/subject_heading_types.yml
+++ b/spec/fixtures/subject_heading_types.yml
@@ -28,7 +28,7 @@ subject_heading_type_00003:
 #
 # Table name: subject_heading_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/fixtures/subject_types.yml
+++ b/spec/fixtures/subject_types.yml
@@ -31,7 +31,7 @@ subject_type_00004:
 #
 # Table name: subject_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/fixtures/subjects.yml
+++ b/spec/fixtures/subjects.yml
@@ -60,7 +60,7 @@ subject_00005:
 #
 # Table name: subjects
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  parent_id               :integer
 #  use_term_id             :integer
 #  term                    :string

--- a/spec/fixtures/subscribes.yml
+++ b/spec/fixtures/subscribes.yml
@@ -34,7 +34,7 @@ subscription_00005:
 #
 # Table name: subscribes
 #
-#  id              :integer          not null, primary key
+#  id              :bigint           not null, primary key
 #  subscription_id :integer          not null
 #  work_id         :integer          not null
 #  start_at        :datetime         not null

--- a/spec/fixtures/subscriptions.yml
+++ b/spec/fixtures/subscriptions.yml
@@ -14,7 +14,7 @@ subscription_00002:
 #
 # Table name: subscriptions
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  title            :text             not null
 #  note             :text
 #  user_id          :integer

--- a/spec/fixtures/use_restrictions.yml
+++ b/spec/fixtures/use_restrictions.yml
@@ -82,7 +82,7 @@ use_restriction_00013:
 #
 # Table name: use_restrictions
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/fixtures/user_checkout_stats.yml
+++ b/spec/fixtures/user_checkout_stats.yml
@@ -18,7 +18,7 @@ two:
 #
 # Table name: user_checkout_stats
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text

--- a/spec/fixtures/user_export_files.yml
+++ b/spec/fixtures/user_export_files.yml
@@ -14,7 +14,7 @@ user_export_file_00003:
 #
 # Table name: user_export_files
 #
-#  id                       :integer          not null, primary key
+#  id                       :bigint           not null, primary key
 #  user_id                  :integer
 #  user_export_file_name    :string
 #  user_export_content_type :string

--- a/spec/fixtures/user_group_has_checkout_types.yml
+++ b/spec/fixtures/user_group_has_checkout_types.yml
@@ -92,7 +92,7 @@ user_group_has_checkout_type_00008:
 #
 # Table name: user_group_has_checkout_types
 #
-#  id                              :integer          not null, primary key
+#  id                              :bigint           not null, primary key
 #  user_group_id                   :integer          not null
 #  checkout_type_id                :integer          not null
 #  checkout_limit                  :integer          default(0), not null

--- a/spec/fixtures/user_groups.yml
+++ b/spec/fixtures/user_groups.yml
@@ -34,8 +34,8 @@ user_group_00003:
 #
 # Table name: user_groups
 #
-#  id                               :integer          not null, primary key
-#  name                             :string
+#  id                               :bigint           not null, primary key
+#  name                             :string           not null
 #  display_name                     :text
 #  note                             :text
 #  position                         :integer

--- a/spec/fixtures/user_has_roles.yml
+++ b/spec/fixtures/user_has_roles.yml
@@ -32,7 +32,7 @@ user4:
 #
 # Table name: user_has_roles
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  user_id    :integer          not null
 #  role_id    :integer          not null
 #  created_at :datetime         not null

--- a/spec/fixtures/user_import_files.yml
+++ b/spec/fixtures/user_import_files.yml
@@ -30,7 +30,7 @@ two:
 #
 # Table name: user_import_files
 #
-#  id                       :integer          not null, primary key
+#  id                       :bigint           not null, primary key
 #  user_id                  :integer
 #  note                     :text
 #  executed_at              :datetime

--- a/spec/fixtures/user_import_results.yml
+++ b/spec/fixtures/user_import_results.yml
@@ -16,7 +16,7 @@ two:
 #
 # Table name: user_import_results
 #
-#  id                  :integer          not null, primary key
+#  id                  :bigint           not null, primary key
 #  user_import_file_id :integer
 #  user_id             :integer
 #  body                :text

--- a/spec/fixtures/user_reserve_stats.yml
+++ b/spec/fixtures/user_reserve_stats.yml
@@ -18,7 +18,7 @@ two:
 #
 # Table name: user_reserve_stats
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text

--- a/spec/models/accept_spec.rb
+++ b/spec/models/accept_spec.rb
@@ -17,7 +17,7 @@ end
 #
 # Table name: accepts
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  basket_id    :integer
 #  item_id      :integer
 #  librarian_id :integer

--- a/spec/models/agent_import_file_spec.rb
+++ b/spec/models/agent_import_file_spec.rb
@@ -88,7 +88,7 @@ end
 #
 # Table name: agent_import_files
 #
-#  id                        :integer          not null, primary key
+#  id                        :bigint           not null, primary key
 #  parent_id                 :integer
 #  content_type              :string
 #  size                      :integer

--- a/spec/models/agent_import_result_spec.rb
+++ b/spec/models/agent_import_result_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: agent_import_results
 #
-#  id                   :integer          not null, primary key
+#  id                   :bigint           not null, primary key
 #  agent_import_file_id :integer
 #  agent_id             :integer
 #  body                 :text

--- a/spec/models/agent_merge_list_spec.rb
+++ b/spec/models/agent_merge_list_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: agent_merge_lists
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/models/agent_merge_spec.rb
+++ b/spec/models/agent_merge_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: agent_merges
 #
-#  id                  :integer          not null, primary key
+#  id                  :bigint           not null, primary key
 #  agent_id            :integer          not null
 #  agent_merge_list_id :integer          not null
 #  created_at          :datetime         not null

--- a/spec/models/agent_relationship_spec.rb
+++ b/spec/models/agent_relationship_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: agent_relationships
 #
-#  id                         :integer          not null, primary key
+#  id                         :bigint           not null, primary key
 #  parent_id                  :integer
 #  child_id                   :integer
 #  agent_relationship_type_id :integer

--- a/spec/models/agent_relationship_type_spec.rb
+++ b/spec/models/agent_relationship_type_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: agent_relationship_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -73,7 +73,7 @@ end
 #
 # Table name: agents
 #
-#  id                                  :integer          not null, primary key
+#  id                                  :bigint           not null, primary key
 #  last_name                           :string
 #  middle_name                         :string
 #  first_name                          :string

--- a/spec/models/agent_type_spec.rb
+++ b/spec/models/agent_type_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: agent_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/models/basket_spec.rb
+++ b/spec/models/basket_spec.rb
@@ -56,7 +56,7 @@ end
 #
 # Table name: baskets
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  user_id      :integer
 #  note         :text
 #  lock_version :integer          default(0), not null

--- a/spec/models/bookstore_spec.rb
+++ b/spec/models/bookstore_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: bookstores
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  name             :text             not null
 #  zip_code         :string
 #  address          :text

--- a/spec/models/budget_type_spec.rb
+++ b/spec/models/budget_type_spec.rb
@@ -10,8 +10,8 @@ end
 #
 # Table name: budget_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/spec/models/carrier_type_has_checkout_type_spec.rb
+++ b/spec/models/carrier_type_has_checkout_type_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: carrier_type_has_checkout_types
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  carrier_type_id  :integer          not null
 #  checkout_type_id :integer          not null
 #  note             :text

--- a/spec/models/carrier_type_spec.rb
+++ b/spec/models/carrier_type_spec.rb
@@ -13,7 +13,7 @@ end
 #
 # Table name: carrier_types
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  name                    :string           not null
 #  display_name            :text
 #  note                    :text

--- a/spec/models/checked_item_spec.rb
+++ b/spec/models/checked_item_spec.rb
@@ -33,7 +33,7 @@ end
 #
 # Table name: checked_items
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  item_id      :integer          not null
 #  basket_id    :integer          not null
 #  librarian_id :integer

--- a/spec/models/checkin_spec.rb
+++ b/spec/models/checkin_spec.rb
@@ -39,7 +39,7 @@ end
 #
 # Table name: checkins
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  item_id      :integer          not null
 #  librarian_id :integer
 #  basket_id    :integer

--- a/spec/models/checkout_spec.rb
+++ b/spec/models/checkout_spec.rb
@@ -61,7 +61,7 @@ end
 #
 # Table name: checkouts
 #
-#  id                     :integer          not null, primary key
+#  id                     :bigint           not null, primary key
 #  user_id                :integer
 #  item_id                :integer          not null
 #  checkin_id             :integer

--- a/spec/models/checkout_stat_has_manifestation_spec.rb
+++ b/spec/models/checkout_stat_has_manifestation_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: checkout_stat_has_manifestations
 #
-#  id                             :integer          not null, primary key
+#  id                             :bigint           not null, primary key
 #  manifestation_checkout_stat_id :integer          not null
 #  manifestation_id               :integer          not null
 #  checkouts_count                :integer

--- a/spec/models/checkout_stat_has_user_spec.rb
+++ b/spec/models/checkout_stat_has_user_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: checkout_stat_has_users
 #
-#  id                    :integer          not null, primary key
+#  id                    :bigint           not null, primary key
 #  user_checkout_stat_id :integer          not null
 #  user_id               :integer          not null
 #  checkouts_count       :integer          default(0), not null

--- a/spec/models/checkout_type_spec.rb
+++ b/spec/models/checkout_type_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: checkout_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/models/circulation_status_spec.rb
+++ b/spec/models/circulation_status_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: circulation_statuses
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/models/content_type_spec.rb
+++ b/spec/models/content_type_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: content_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: countries
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  alpha_2      :string

--- a/spec/models/create_spec.rb
+++ b/spec/models/create_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: creates
 #
-#  id             :integer          not null, primary key
+#  id             :bigint           not null, primary key
 #  agent_id       :integer          not null
 #  work_id        :integer          not null
 #  position       :integer

--- a/spec/models/create_type_spec.rb
+++ b/spec/models/create_type_spec.rb
@@ -10,8 +10,8 @@ end
 #
 # Table name: create_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/spec/models/donate_spec.rb
+++ b/spec/models/donate_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: donates
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  agent_id   :integer          not null
 #  item_id    :integer          not null
 #  created_at :datetime         not null

--- a/spec/models/form_of_work_spec.rb
+++ b/spec/models/form_of_work_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: form_of_works
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/models/frequency_spec.rb
+++ b/spec/models/frequency_spec.rb
@@ -12,7 +12,7 @@ end
 #
 # Table name: frequencies
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/models/identifier_spec.rb
+++ b/spec/models/identifier_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: identifiers
 #
-#  id                 :integer          not null, primary key
+#  id                 :bigint           not null, primary key
 #  body               :string           not null
 #  identifier_type_id :integer          not null
 #  manifestation_id   :integer

--- a/spec/models/identifier_type_spec.rb
+++ b/spec/models/identifier_type_spec.rb
@@ -9,8 +9,8 @@ end
 #
 # Table name: identifier_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/spec/models/import_request_spec.rb
+++ b/spec/models/import_request_spec.rb
@@ -17,7 +17,7 @@ end
 #
 # Table name: import_requests
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  isbn             :string
 #  manifestation_id :integer
 #  user_id          :integer

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -42,7 +42,7 @@ end
 #
 # Table name: items
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  call_number             :string
 #  item_identifier         :string
 #  created_at              :datetime         not null

--- a/spec/models/language_spec.rb
+++ b/spec/models/language_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: languages
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  native_name  :string
 #  display_name :text

--- a/spec/models/library_group_spec.rb
+++ b/spec/models/library_group_spec.rb
@@ -27,7 +27,7 @@ end
 #
 # Table name: library_groups
 #
-#  id                            :integer          not null, primary key
+#  id                            :bigint           not null, primary key
 #  name                          :string           not null
 #  display_name                  :text
 #  short_name                    :string           not null

--- a/spec/models/library_spec.rb
+++ b/spec/models/library_spec.rb
@@ -17,7 +17,7 @@ end
 #
 # Table name: libraries
 #
-#  id                    :integer          not null, primary key
+#  id                    :bigint           not null, primary key
 #  name                  :string           not null
 #  display_name          :text
 #  short_display_name    :string           not null

--- a/spec/models/license_spec.rb
+++ b/spec/models/license_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: licenses
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :string
 #  note         :text

--- a/spec/models/manifestation_checkout_stat_spec.rb
+++ b/spec/models/manifestation_checkout_stat_spec.rb
@@ -19,7 +19,7 @@ end
 #
 # Table name: manifestation_checkout_stats
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text

--- a/spec/models/manifestation_relationship_spec.rb
+++ b/spec/models/manifestation_relationship_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: manifestation_relationships
 #
-#  id                                 :integer          not null, primary key
+#  id                                 :bigint           not null, primary key
 #  parent_id                          :integer
 #  child_id                           :integer
 #  manifestation_relationship_type_id :integer

--- a/spec/models/manifestation_relationship_type_spec.rb
+++ b/spec/models/manifestation_relationship_type_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: manifestation_relationship_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/models/manifestation_reserve_stat_spec.rb
+++ b/spec/models/manifestation_reserve_stat_spec.rb
@@ -19,7 +19,7 @@ end
 #
 # Table name: manifestation_reserve_stats
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text

--- a/spec/models/manifestation_spec.rb
+++ b/spec/models/manifestation_spec.rb
@@ -279,7 +279,7 @@ end
 #
 # Table name: manifestations
 #
-#  id                              :integer          not null, primary key
+#  id                              :bigint           not null, primary key
 #  original_title                  :text             not null
 #  title_alternative               :text
 #  title_transcription             :text

--- a/spec/models/medium_of_performance_spec.rb
+++ b/spec/models/medium_of_performance_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: medium_of_performances
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/models/news_feed_spec.rb
+++ b/spec/models/news_feed_spec.rb
@@ -28,7 +28,7 @@ end
 #
 # Table name: news_feeds
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  library_group_id :integer          default(1), not null
 #  title            :string
 #  url              :string

--- a/spec/models/news_post_spec.rb
+++ b/spec/models/news_post_spec.rb
@@ -7,7 +7,7 @@ end
 #
 # Table name: news_posts
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  title            :text
 #  body             :text
 #  user_id          :integer

--- a/spec/models/own_spec.rb
+++ b/spec/models/own_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: owns
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  agent_id   :integer          not null
 #  item_id    :integer          not null
 #  position   :integer

--- a/spec/models/picture_file_spec.rb
+++ b/spec/models/picture_file_spec.rb
@@ -15,7 +15,7 @@ end
 #
 # Table name: picture_files
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  picture_attachable_id   :integer
 #  picture_attachable_type :string
 #  title                   :text

--- a/spec/models/produce_spec.rb
+++ b/spec/models/produce_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: produces
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  agent_id         :integer          not null
 #  manifestation_id :integer          not null
 #  position         :integer

--- a/spec/models/produce_type_spec.rb
+++ b/spec/models/produce_type_spec.rb
@@ -10,8 +10,8 @@ end
 #
 # Table name: produce_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -55,7 +55,7 @@ end
 #
 # Table name: profiles
 #
-#  id                       :integer          not null, primary key
+#  id                       :bigint           not null, primary key
 #  user_id                  :integer
 #  user_group_id            :integer
 #  library_id               :integer

--- a/spec/models/realize_spec.rb
+++ b/spec/models/realize_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: realizes
 #
-#  id              :integer          not null, primary key
+#  id              :bigint           not null, primary key
 #  agent_id        :integer          not null
 #  expression_id   :integer          not null
 #  position        :integer

--- a/spec/models/realize_type_spec.rb
+++ b/spec/models/realize_type_spec.rb
@@ -10,8 +10,8 @@ end
 #
 # Table name: realize_types
 #
-#  id           :integer          not null, primary key
-#  name         :string
+#  id           :bigint           not null, primary key
+#  name         :string           not null
 #  display_name :text
 #  note         :text
 #  position     :integer

--- a/spec/models/request_status_type_spec.rb
+++ b/spec/models/request_status_type_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: request_status_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/models/request_type_spec.rb
+++ b/spec/models/request_type_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: request_types
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/models/reserve_spec.rb
+++ b/spec/models/reserve_spec.rb
@@ -132,7 +132,7 @@ end
 #
 # Table name: reserves
 #
-#  id                           :integer          not null, primary key
+#  id                           :bigint           not null, primary key
 #  user_id                      :integer          not null
 #  manifestation_id             :integer          not null
 #  item_id                      :integer

--- a/spec/models/reserve_stat_has_manifestation_spec.rb
+++ b/spec/models/reserve_stat_has_manifestation_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: reserve_stat_has_manifestations
 #
-#  id                            :integer          not null, primary key
+#  id                            :bigint           not null, primary key
 #  manifestation_reserve_stat_id :integer          not null
 #  manifestation_id              :integer          not null
 #  reserves_count                :integer

--- a/spec/models/reserve_stat_has_user_spec.rb
+++ b/spec/models/reserve_stat_has_user_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: reserve_stat_has_users
 #
-#  id                   :integer          not null, primary key
+#  id                   :bigint           not null, primary key
 #  user_reserve_stat_id :integer          not null
 #  user_id              :integer          not null
 #  reserves_count       :integer

--- a/spec/models/resource_export_file_spec.rb
+++ b/spec/models/resource_export_file_spec.rb
@@ -28,7 +28,7 @@ end
 #
 # Table name: resource_export_files
 #
-#  id                           :integer          not null, primary key
+#  id                           :bigint           not null, primary key
 #  user_id                      :integer
 #  resource_export_file_name    :string
 #  resource_export_content_type :string

--- a/spec/models/resource_import_file_spec.rb
+++ b/spec/models/resource_import_file_spec.rb
@@ -472,7 +472,7 @@ end
 #
 # Table name: resource_import_files
 #
-#  id                           :integer          not null, primary key
+#  id                           :bigint           not null, primary key
 #  parent_id                    :integer
 #  content_type                 :string
 #  size                         :integer

--- a/spec/models/resource_import_result_spec.rb
+++ b/spec/models/resource_import_result_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: resource_import_results
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  resource_import_file_id :integer
 #  manifestation_id        :integer
 #  item_id                 :integer

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -28,7 +28,7 @@ end
 #
 # Table name: roles
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :string
 #  note         :text

--- a/spec/models/search_engine_spec.rb
+++ b/spec/models/search_engine_spec.rb
@@ -12,7 +12,7 @@ end
 #
 # Table name: search_engines
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  name             :string           not null
 #  display_name     :text
 #  url              :string           not null

--- a/spec/models/series_statement_merge_list_spec.rb
+++ b/spec/models/series_statement_merge_list_spec.rb
@@ -12,7 +12,7 @@ end
 #
 # Table name: series_statement_merge_lists
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/models/series_statement_merge_spec.rb
+++ b/spec/models/series_statement_merge_spec.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: series_statement_merges
 #
-#  id                             :integer          not null, primary key
+#  id                             :bigint           not null, primary key
 #  series_statement_id            :integer          not null
 #  series_statement_merge_list_id :integer          not null
 #  created_at                     :datetime         not null

--- a/spec/models/series_statement_spec.rb
+++ b/spec/models/series_statement_spec.rb
@@ -13,7 +13,7 @@ end
 #
 # Table name: series_statements
 #
-#  id                                 :integer          not null, primary key
+#  id                                 :bigint           not null, primary key
 #  original_title                     :text
 #  numbering                          :text
 #  title_subseries                    :text

--- a/spec/models/shelf_spec.rb
+++ b/spec/models/shelf_spec.rb
@@ -13,7 +13,7 @@ end
 #
 # Table name: shelves
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  name         :string           not null
 #  display_name :text
 #  note         :text

--- a/spec/models/subscribe_spec.rb
+++ b/spec/models/subscribe_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: subscribes
 #
-#  id              :integer          not null, primary key
+#  id              :bigint           not null, primary key
 #  subscription_id :integer          not null
 #  work_id         :integer          not null
 #  start_at        :datetime         not null

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -12,7 +12,7 @@ end
 #
 # Table name: subscriptions
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  title            :text             not null
 #  note             :text
 #  user_id          :integer

--- a/spec/models/user_checkout_stat_spec.rb
+++ b/spec/models/user_checkout_stat_spec.rb
@@ -19,7 +19,7 @@ end
 #
 # Table name: user_checkout_stats
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text

--- a/spec/models/user_export_file_spec.rb
+++ b/spec/models/user_export_file_spec.rb
@@ -17,7 +17,7 @@ end
 #
 # Table name: user_export_files
 #
-#  id                       :integer          not null, primary key
+#  id                       :bigint           not null, primary key
 #  user_id                  :integer
 #  user_export_file_name    :string
 #  user_export_content_type :string

--- a/spec/models/user_group_has_checkout_type_spec.rb
+++ b/spec/models/user_group_has_checkout_type_spec.rb
@@ -12,7 +12,7 @@ end
 #
 # Table name: user_group_has_checkout_types
 #
-#  id                              :integer          not null, primary key
+#  id                              :bigint           not null, primary key
 #  user_group_id                   :integer          not null
 #  checkout_type_id                :integer          not null
 #  checkout_limit                  :integer          default(0), not null

--- a/spec/models/user_group_spec.rb
+++ b/spec/models/user_group_spec.rb
@@ -20,8 +20,8 @@ end
 #
 # Table name: user_groups
 #
-#  id                               :integer          not null, primary key
-#  name                             :string
+#  id                               :bigint           not null, primary key
+#  name                             :string           not null
 #  display_name                     :text
 #  note                             :text
 #  position                         :integer

--- a/spec/models/user_has_role_spec.rb
+++ b/spec/models/user_has_role_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: user_has_roles
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  user_id    :integer          not null
 #  role_id    :integer          not null
 #  created_at :datetime         not null

--- a/spec/models/user_import_file_spec.rb
+++ b/spec/models/user_import_file_spec.rb
@@ -251,7 +251,7 @@ end
 #
 # Table name: user_import_files
 #
-#  id                       :integer          not null, primary key
+#  id                       :bigint           not null, primary key
 #  user_id                  :integer
 #  note                     :text
 #  executed_at              :datetime

--- a/spec/models/user_import_result_spec.rb
+++ b/spec/models/user_import_result_spec.rb
@@ -9,7 +9,7 @@ end
 #
 # Table name: user_import_results
 #
-#  id                  :integer          not null, primary key
+#  id                  :bigint           not null, primary key
 #  user_import_file_id :integer
 #  user_id             :integer
 #  body                :text

--- a/spec/models/user_reserve_stat_spec.rb
+++ b/spec/models/user_reserve_stat_spec.rb
@@ -19,7 +19,7 @@ end
 #
 # Table name: user_reserve_stats
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  start_date   :datetime
 #  end_date     :datetime
 #  note         :text

--- a/spec/models/withdraw_spec.rb
+++ b/spec/models/withdraw_spec.rb
@@ -28,7 +28,7 @@ end
 #
 # Table name: withdraws
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  basket_id    :integer
 #  item_id      :integer
 #  librarian_id :integer


### PR DESCRIPTION
新しいバージョンのRailsでは、idカラムをbigint型で作成するようになっているため、それにあわせて既存のidカラムのデータ型を変更する。