### PR TITLE
user_idカラムに外部キーを追加

### DIFF
--- a/db/migrate/20221114063534_add_foreign_key_to_agent_import_files_referencing_user.rb
+++ b/db/migrate/20221114063534_add_foreign_key_to_agent_import_files_referencing_user.rb
@@ -1,0 +1,16 @@
+class AddForeignKeyToAgentImportFilesReferencingUser < ActiveRecord::Migration[6.1]
+  def change
+    add_foreign_key :agent_import_files, :users
+    add_foreign_key :baskets, :users
+    add_foreign_key :bookmarks, :users
+    add_foreign_key :event_export_files, :users
+    add_foreign_key :import_requests, :users
+    add_foreign_key :inventory_files, :users
+    add_foreign_key :news_posts, :users
+    add_foreign_key :resource_export_files, :users
+    add_foreign_key :resource_import_files, :users
+    add_foreign_key :subscriptions, :users
+    add_foreign_key :user_export_files, :users
+    add_foreign_key :user_import_files, :users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_12_165013) do
+ActiveRecord::Schema.define(version: 2022_11_14_063534) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1763,6 +1763,9 @@ ActiveRecord::Schema.define(version: 2022_11_12_165013) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "agent_import_files", "users"
+  add_foreign_key "baskets", "users"
+  add_foreign_key "bookmarks", "users"
   add_foreign_key "carrier_type_has_checkout_types", "carrier_types"
   add_foreign_key "carrier_type_has_checkout_types", "checkout_types"
   add_foreign_key "checked_items", "baskets"
@@ -1780,8 +1783,11 @@ ActiveRecord::Schema.define(version: 2022_11_12_165013) do
   add_foreign_key "demands", "items"
   add_foreign_key "demands", "messages"
   add_foreign_key "demands", "users"
+  add_foreign_key "event_export_files", "users"
   add_foreign_key "events", "event_categories"
+  add_foreign_key "import_requests", "users"
   add_foreign_key "inventory_files", "shelves"
+  add_foreign_key "inventory_files", "users"
   add_foreign_key "item_custom_values", "item_custom_properties"
   add_foreign_key "item_custom_values", "items"
   add_foreign_key "item_has_use_restrictions", "items"
@@ -1797,16 +1803,22 @@ ActiveRecord::Schema.define(version: 2022_11_12_165013) do
   add_foreign_key "messages", "messages", column: "parent_id"
   add_foreign_key "ndl_bib_id_records", "manifestations"
   add_foreign_key "ndla_records", "agents"
+  add_foreign_key "news_posts", "users"
   add_foreign_key "profiles", "users"
   add_foreign_key "reserve_stat_has_manifestations", "manifestations"
   add_foreign_key "reserve_stat_has_users", "user_reserve_stats"
   add_foreign_key "reserve_stat_has_users", "users"
   add_foreign_key "reserves", "manifestations"
   add_foreign_key "reserves", "users"
+  add_foreign_key "resource_export_files", "users"
+  add_foreign_key "resource_import_files", "users"
+  add_foreign_key "subscriptions", "users"
   add_foreign_key "user_checkout_stats", "users"
+  add_foreign_key "user_export_files", "users"
   add_foreign_key "user_group_has_checkout_types", "checkout_types"
   add_foreign_key "user_group_has_checkout_types", "user_groups"
   add_foreign_key "user_has_roles", "roles"
   add_foreign_key "user_has_roles", "users"
+  add_foreign_key "user_import_files", "users"
   add_foreign_key "user_reserve_stats", "users"
 end


### PR DESCRIPTION
各テーブルに存在するuser_idカラムの値を、usersテーブルのidカラムに存在するものに制限しています。