### PR TITLE
paperclip gemをkt-paperclip gemに置き換え

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'devise'
 gem 'pundit'
 gem 'sunspot_rails'
-gem 'paperclip'
+gem 'kt-paperclip'
 gem 'acts_as_list'
 gem 'kaminari'
 gem 'strip_attributes'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,12 @@ GEM
     kaminari-core (1.2.2)
     kramdown (2.4.0)
       rexml
+    kt-paperclip (7.1.1)
+      activemodel (>= 4.2.0)
+      activesupport (>= 4.2.0)
+      marcel (~> 1.0.1)
+      mime-types
+      terrapin (~> 0.6.0)
     library_stdnums (1.6.0)
     link_header (0.0.8)
     lisbn (0.3.2)
@@ -222,9 +228,6 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
-    mimemagic (0.3.10)
-      nokogiri (~> 1)
-      rake
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     minitest (5.16.3)
@@ -244,12 +247,6 @@ GEM
       faraday-follow_redirects (>= 0.3.0, < 2)
     options (2.3.2)
     orm_adapter (0.5.0)
-    paperclip (6.1.0)
-      activemodel (>= 4.2.0)
-      activesupport (>= 4.2.0)
-      mime-types
-      mimemagic (~> 0.3.0)
-      terrapin (~> 0.6.0)
     parallel (1.22.1)
     parallel_tests (4.0.0)
       parallel
@@ -492,11 +489,11 @@ DEPENDENCIES
   jquery-ui-rails (~> 4.2.1)
   kaminari
   kramdown
+  kt-paperclip
   library_stdnums
   lisbn
   listen (~> 3.3)
   oai
-  paperclip
   parallel_tests
   pg (~> 1.1)
   pretender


### PR DESCRIPTION
paperclip gemはRuby 3.0の環境でマイグレーションの実行に失敗する不具合がある。
https://stackoverflow.com/questions/66331614/when-i-use-paperclip-migration-error-occur

このため、派生版のkt-paperclipに置き換える。
https://github.com/kreeti/kt-paperclip

なお、ファイル添付機能はActiveStorageに移行しているが、ファイルの移行のため、paperclipの読み込み自体は残している。