### PR TITLE
MinIOのパスワードとバケット名の設定を追加

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -11,6 +11,9 @@ REDIS_URL=redis://redis/enju-leaf-${RAILS_ENV}
 
 SOLR_URL=http://solr:8983/solr/enju_leaf_${RAILS_ENV}
 
+MINIO_ROOT_USER=enju
+MINIO_ROOT_PASSWORD=password
+
 ENJU_LEAF_BIND_ADDRESS=127.0.0.1
 ENJU_LEAF_BASE_URL=http://localhost:8080
 ENJU_LEAF_DEFAULT_LOCALE=ja

--- a/app/views/user_export_files/index.html.erb
+++ b/app/views/user_export_files/index.html.erb
@@ -19,7 +19,7 @@
         <td><%= link_to user_export_file.id, user_export_file %></td>
         <td><%= user_export_file.user.try(:username) %></td>
         <td>
-          <%= link_to user_export_file.user_export.filename, rails_blob_path(user_export_file.attachment) if user_export_file.attachment.attached? %>
+          <%= link_to user_export_file.attachment.filename, rails_blob_path(user_export_file.attachment) if user_export_file.attachment.attached? %>
           <br />
           <%= user_export_file.created_at %>
         </td>

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -11,7 +11,7 @@ minio:
   access_key_id: <%= ENV['MINIO_ROOT_USER'] || Rails.application.credentials.dig(:minio, :access_key_id) %>
   secret_access_key: <%= ENV['MINIO_ROOT_PASSWORD'] || Rails.application.credentials.dig(:minio, :secret_access_key) %>
   region: us-east-1
-  bucket: <%= ENV['ENJU_LEAF_STORAGE_BUCKET'] || 'enju-leaf' %>-<%= Rails.env %>
+  bucket: <%= ENV['ENJU_LEAF_STORAGE_BUCKET'] %>-<%= Rails.env %>
   force_path_style: true
   endpoint: <%= ENV['ENJU_LEAF_STORAGE_ENDPOINT'] || 'http://minio:9000' %>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
     volumes:
       - minio:/data
     entrypoint:
-      /bin/sh -c "mkdir -p /data/${ENJU_LEAF_STORAGE_BUCKET} && minio server /data --console-address \":9001\""
+      /bin/sh -c "mkdir -p /data/${ENJU_LEAF_STORAGE_BUCKET}-${RAILS_ENV} && minio server /data --console-address \":9001\""
     expose:
       - 9000
       - 9001


### PR DESCRIPTION
MinIOの起動時に、以下を設定します。

- ユーザ名に環境変数`MINIO_ROOT_USER`、パスワードに`MINIO_ROOT_PASSWORD`の中身を設定します。
- 起動時に`enju-leaf-#{Rails.env}`という名前のバケットを作成します。たとえば、development環境であれば`enju-leaf-development`になります。