### PR TITLE
Eventのエクスポートの際のファイル名を指定

### DIFF
--- a/app/models/event_export_file.rb
+++ b/app/models/event_export_file.rb
@@ -29,14 +29,14 @@ class EventExportFile < ApplicationRecord
     to: :state_machine
 
   def export!
-    role_name = user.try(:role).try(:name)
+    role_name = user&.role&.name || 'Guest'
     tsv = Event.export(role: role_name)
+    file = StringIO.new(tsv)
+    file.class.class_eval { attr_accessor :original_filename, :content_type }
+    file.original_filename = 'event_export.txt'
 
     EventExportFile.transaction do
       transition_to!(:started)
-      role_name = user.try(:role).try(:name)
-      self.event_export = StringIO.new(tsv)
-      self.event_export.instance_write(:filename, "event_export.txt")
       save!
       transition_to!(:completed)
     end

--- a/app/models/event_export_file.rb
+++ b/app/models/event_export_file.rb
@@ -37,6 +37,7 @@ class EventExportFile < ApplicationRecord
 
     EventExportFile.transaction do
       transition_to!(:started)
+      self.event_export = file
       save!
       transition_to!(:completed)
     end

--- a/spec/models/event_export_file_spec.rb
+++ b/spec/models/event_export_file_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+ 
+describe EventExportFile do
+  fixtures :all
+  
+  it "should export events" do
+    export_file = EventExportFile.create!(user: users(:admin))
+    export_file.export!
+    expect(export_file.event_export_file_name).to eq 'event_export.txt'
+  end
+end
+
+# == Schema Information
+#
+# Table name: event_export_files
+#
+#  id                        :integer          not null, primary key
+#  user_id                   :integer
+#  event_export_file_name    :string
+#  event_export_content_type :string
+#  event_export_file_size    :bigint
+#  event_export_updated_at   :datetime
+#  executed_at               :datetime
+#  created_at                :datetime
+#  updated_at                :datetime
+#


### PR DESCRIPTION
https://github.com/next-l/enju_leaf/issues/1779 の修正です。`event_export.txt`となります。