### PR TITLE
Dockerのイメージタグにruby:3.1.4-bullseyeを指定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.4 as builder
+FROM ruby:3.1.4-bullseye as builder
 LABEL maintainer="nabeta@fastmail.fm"
 
 ARG http_proxy
@@ -8,7 +8,7 @@ COPY Gemfile /
 COPY Gemfile.lock /
 RUN apt-get update -qq && apt-get install -y libpq-dev && bundle install
 
-FROM ruby:3.1.4
+FROM ruby:3.1.4-bullseye
 LABEL maintainer="nabeta@fastmail.fm"
 
 ARG http_proxy


### PR DESCRIPTION
`ruby-3.1.4`のベースイメージがDebian 12(bookworm)になったため、以前と同じDebian 11(bullseye)を使用するように指定しています。