### PR TITLE
nginxのレスポンスヘッダのサイズを増加

### DIFF
--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -6,6 +6,9 @@ server {
   # アップロードできるファイルの最大サイズ
   client_max_body_size 5m;
 
+  proxy_buffers 8 16K;
+  proxy_buffer_size 16k;
+
   root /opt/enju_leaf/public;
 
   # Enjuのその他の機能へのアクセスの設定


### PR DESCRIPTION
development環境で起動した際、nginxに以下のエラーが出て、Webブラウザでアクセスできない。

```
enju_leaf-nginx-1       | 2023/07/09 02:39:30 [error] 33#33: *1 upstream sent too big header while reading response header from upstream, client: 172.20.0.1, server: _, request: "GET / HTTP/1.1", upstream: "http://172.20.0.8:3000/", host: "localhost:8080"
```

このPRでは、レスポンスヘッダのサイズを16KBに増やしている。
http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size