### PR TITLE
REDIS_URLの指定方法を修正

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,7 +7,7 @@ POSTGRES_HOST=postgres
 POSTGRES_PASSWORD=password
 DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}/enju_leaf_${RAILS_ENV}
 
-REDIS_URL=redis://redis/enju-leaf-${RAILS_ENV}
+REDIS_URL=redis://redis
 
 SOLR_URL=http://solr:8983/solr/enju_leaf_${RAILS_ENV}
 


### PR DESCRIPTION
`.env`ではREDIS_URLにデータベース名を指定できるかのように記述していたが、実際にはRedisではデータベース名を指定できない。  
https://stackoverflow.com/questions/35931043/how-can-i-change-the-name-of-databases-in-redis