### PR TITLE
ActiveStorageの保存先をローカルに変更

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -13,8 +13,8 @@ SOLR_URL=http://solr:8983/solr/enju_leaf_${RAILS_ENV}
 
 TIKA_URL=http://tika:9998
 
-MINIO_ROOT_USER=enju
-MINIO_ROOT_PASSWORD=password
+# MINIO_ROOT_USER=enju
+# MINIO_ROOT_PASSWORD=password
 
 ENJU_LEAF_BIND_ADDRESS=127.0.0.1
 ENJU_LEAF_BASE_URL=http://localhost:8080

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :minio
+  config.active_storage.service = :local
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ volumes:
   postgres:
   solr:
   redis:
-  minio:
 
 networks:
   internal:
@@ -30,7 +29,6 @@ x-app: &app
     - postgres
     - solr
     - redis
-    # - minio
   restart: always
 
 services:
@@ -106,28 +104,6 @@ services:
       test: ["CMD-SHELL", "redis-cli ping"]
       interval: 30s
       timeout: 5s
-      retries: 3
-
-  minio:
-    image: quay.io/minio/minio:RELEASE.2023-05-18T00-05-36Z
-    profiles:
-      - develop
-    volumes:
-      - minio:/data
-    entrypoint:
-      /bin/sh -c "mkdir -p /data/${ENJU_LEAF_STORAGE_BUCKET}-${RAILS_ENV} && minio server /data --console-address \":9001\""
-    expose:
-      - 9000
-      - 9001
-    env_file:
-      - .env
-    restart: always
-    networks:
-      internal:
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
       retries: 3
 
   cantaloupe:


### PR DESCRIPTION
バックアップ・リストア・アップデートの手順が複雑になることと、MinIOのライセンスがApache 2.0からAGPLに変わっており、再配布の際に問題が発生する可能性があることから、既定での利用を行わないようにしました。