### PR TITLE
IdentifierTypeのクラス名の誤りを修正

### DIFF
--- a/app/models/concerns/enju_loc/enju_manifestation.rb
+++ b/app/models/concerns/enju_loc/enju_manifestation.rb
@@ -114,14 +114,14 @@ module EnjuLoc
             identifier[:isbn] = Identifier.new(
               manifestation: manifestation,
               body: isbn,
-              identifier_type: IdentifierType.find_by(name: 'isbn') || IdnetifierType.create!(name: 'isbn')
+              identifier_type: IdentifierType.find_by(name: 'isbn') || IdentifierType.create!(name: 'isbn')
             )
           end
           if loc_identifier
             identifier[:loc_identifier] = Identifier.new(
               manifestation: manifestation,
               body: loc_identifier,
-              identifier_type: IdentifierType.find_by(name: 'loc_identifier') || IdnetifierType.create!(name: 'loc_identifier')
+              identifier_type: IdentifierType.find_by(name: 'loc_identifier') || IdentifierType.create!(name: 'loc_identifier')
             )
           end
           if lccn

--- a/app/models/concerns/enju_ndl/enju_manifestation.rb
+++ b/app/models/concerns/enju_ndl/enju_manifestation.rb
@@ -146,7 +146,7 @@ module EnjuNdl
           identifier = {}
           if isbn
             identifier[:isbn] = Identifier.new(body: isbn)
-            identifier[:isbn].identifier_type = IdentifierType.find_by(name: 'isbn') || IdnetifierType.create!(name: 'isbn')
+            identifier[:isbn].identifier_type = IdentifierType.find_by(name: 'isbn') || IdentifierType.create!(name: 'isbn')
           end
           if iss_itemno
             identifier[:iss_itemno] = Identifier.new(body: iss_itemno)


### PR DESCRIPTION
LC・NDLからのインポートの際、`IdentifierType`でisbnが存在しない場合に作成する処理で、クラス名が間違っていました。ただし、通常IdentifierTypeは削除されないので、問題になることはほとんどないと思います。