### PR TITLE
IssnRecordモデルを追加

### DIFF
--- a/app/helpers/manifestations_helper.rb
+++ b/app/helpers/manifestations_helper.rb
@@ -368,11 +368,11 @@ module ManifestationsHelper
         )
       end
 
-      manifestation.identifier_contents(:issn).each do |i|
+      manifestation.issn_records.each do |i|
         graph << RDF::Statement.new(
           subject,
           nextl.issn,
-          RDF::Literal.new(i)
+          RDF::Literal.new(i.body)
         )
       end
 
@@ -420,14 +420,6 @@ module ManifestationsHelper
         graph << RDF::Statement.new(
           subject,
           nextl.loc_identifier,
-          RDF::Literal.new(i)
-        )
-      end
-
-      manifestation.identifier_contents(:issn_l).each do |i|
-        graph << RDF::Statement.new(
-          subject,
-          nextl.issn_l,
           RDF::Literal.new(i)
         )
       end

--- a/app/models/concerns/enju_loc/enju_manifestation.rb
+++ b/app/models/concerns/enju_loc/enju_manifestation.rb
@@ -124,13 +124,6 @@ module EnjuLoc
               identifier_type: IdentifierType.find_by(name: 'lccn') || IdentifierType.create!(name: 'lccn')
             )
           end
-          if issn
-            identifier[:issn] = Identifier.new(
-              manifestation: manifestation,
-              body: issn,
-              identifier_type: IdentifierType.find_by(name: 'issn') || IdentifierType.create!(name: 'issn')
-            )
-          end
           if issn_l
             identifier[:issn_l] = Identifier.new(
               manifestation: manifestation,
@@ -147,6 +140,7 @@ module EnjuLoc
             manifestation.identifiers << v if v.valid?
           end
           manifestation.isbn_records.create(body: isbn) if isbn.present?
+          manifestation.issn_records.create(body: issn) if issn.present?
           manifestation.publishers << publisher_agents
           manifestation.creators << creator_agents
           create_loc_subject_related_elements(doc, manifestation)

--- a/app/models/issn_record.rb
+++ b/app/models/issn_record.rb
@@ -1,0 +1,45 @@
+class IssnRecord < ApplicationRecord
+  has_many :issn_record_and_manifestations, dependent: :destroy
+  has_many :manifestations, through: :issn_record_and_manifestations
+  validates :body, presence: true, uniqueness: true
+  before_save :normalize_issn
+  strip_attributes
+
+  def normalize_issn
+    if StdNum::ISSN.valid?(body)
+      self.body = StdNum::ISSN.normalize(body)
+    else
+      errors.add(:body)
+    end
+  end
+
+  def self.new_records(issn_records_params)
+    return [] unless issn_records_params
+    issn_records = []
+    IssnRecord.transaction do
+      issn_records_params.each do |k, v|
+        next if v['_destroy'] == '1'
+        if v['body'].present?
+          issn_record = IssnRecord.where(body: v['body'].gsub(/[^0-9x]/i, '')).first_or_create!
+        elsif v['id'].present?
+          issn_record = IssnRecord.find(v['id'])
+        else
+          v.delete('_destroy')
+          issn_record = IssnRecord.create(v)
+        end
+        issn_records << issn_record
+      end
+    end
+    issn_records
+  end
+end
+
+# == Schema Information
+#
+# Table name: issn_records
+#
+#  id         :bigint           not null, primary key
+#  body       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#

--- a/app/models/issn_record_and_manifestation.rb
+++ b/app/models/issn_record_and_manifestation.rb
@@ -1,0 +1,16 @@
+class IssnRecordAndManifestation < ApplicationRecord
+  belongs_to :issn_record
+  belongs_to :manifestation
+end
+
+# == Schema Information
+#
+# Table name: issn_record_and_manifestations
+#
+#  id               :bigint           not null, primary key
+#  issn_record_id   :bigint           not null
+#  manifestation_id :bigint           not null
+#  position         :integer
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -187,7 +187,7 @@ class Manifestation < ApplicationRecord
     end
     text :issn do # 前方一致検索のためtext指定を追加
       if series_statements.exists?
-        [issn_records.pluck(:body), (series_statements.map{|s| s.manifestation.issn_records.pluck(:body))})].flatten.uniq.compact
+        [issn_records.pluck(:body), (series_statements.map{|s| s.manifestation.issn_records.pluck(:body)})].flatten.uniq.compact
       else
         issn_records.pluck(:body)
       end

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -40,6 +40,7 @@ class Manifestation < ApplicationRecord
   accepts_nested_attributes_for :series_statements, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :identifiers, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :manifestation_custom_values, reject_if: :all_blank
+  accepts_nested_attributes_for :issn_records, allow_destroy: true, reject_if: :all_blank
 
   searchable do
     text :title, default_boost: 2 do

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -32,6 +32,8 @@ class Manifestation < ApplicationRecord
   has_one :periodical_record, class_name: 'Periodical', dependent: :destroy
   has_one :periodical_and_manifestation, dependent: :destroy
   has_one :periodical, through: :periodical_and_manifestation, dependent: :destroy
+  has_many :issn_record_and_manifestations, dependent: :destroy
+  has_many :issn_records, through: :issn_record_and_manifestations
   has_one :doi_record, dependent: :destroy
 
   accepts_nested_attributes_for :creators, allow_destroy: true, reject_if: :all_blank

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -83,7 +83,7 @@ class Manifestation < ApplicationRecord
     end
     string :issn, multiple: true do
       if series_statements.exists?
-        [issn_records.pluck(:body), (series_statements.map{|s| s.manifestation.issn_records.pluck(:body))})].flatten.uniq.compact
+        [issn_records.pluck(:body), (series_statements.map{|s| s.manifestation.issn_records.pluck(:body)})].flatten.uniq.compact
       else
         issn_records.pluck(:body)
       end

--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -82,9 +82,9 @@ class Manifestation < ApplicationRecord
     end
     string :issn, multiple: true do
       if series_statements.exists?
-        [identifier_contents(:issn), (series_statements.map{|s| s.manifestation.identifier_contents(:issn)})].flatten.uniq.compact
+        [issn_records.pluck(:body), (series_statements.map{|s| s.manifestation.issn_records.pluck(:body))})].flatten.uniq.compact
       else
-        identifier_contents(:issn)
+        issn_records.pluck(:body)
       end
     end
     string :lccn, multiple: true do
@@ -186,9 +186,9 @@ class Manifestation < ApplicationRecord
     end
     text :issn do # 前方一致検索のためtext指定を追加
       if series_statements.exists?
-        [identifier_contents(:issn), (series_statements.map{|s| s.manifestation.identifier_contents(:issn)})].flatten.uniq.compact
+        [issn_records.pluck(:body), (series_statements.map{|s| s.manifestation.issn_records.pluck(:body))})].flatten.uniq.compact
       else
-        identifier_contents(:issn)
+        issn_records.pluck(:body)
       end
     end
     text :identifier do
@@ -575,7 +575,7 @@ class Manifestation < ApplicationRecord
       frequency: frequency.name,
       language: language.name,
       isbn: identifier_contents(:isbn).join('//'),
-      issn: identifier_contents(:issn).join('//'),
+      issn: issn_records.pluck(:body).join('//'),
       volume_number: volume_number,
       volume_number_string: volume_number_string,
       edition: edition,
@@ -599,7 +599,7 @@ class Manifestation < ApplicationRecord
     }
 
     IdentifierType.find_each do |type|
-      next if ['issn', 'isbn', 'jpno', 'ncid', 'lccn', 'doi'].include?(type.name.downcase.strip)
+      next if ['isbn', 'jpno', 'ncid', 'lccn', 'doi'].include?(type.name.downcase.strip)
 
       record[:"identifier:#{type.name.to_sym}"] = identifiers.where(identifier_type: type).pluck(:body).join('//')
     end

--- a/app/models/resource_import_file.rb
+++ b/app/models/resource_import_file.rb
@@ -765,6 +765,7 @@ end
       end
 
       manifestation.doi_record = set_doi(row)
+      manifestation.issn_records.find_or_create_by(body: row['issn']) if row['issn'].present?
 
       identifiers = set_identifier(row)
 

--- a/app/views/manifestations/_form.html.erb
+++ b/app/views/manifestations/_form.html.erb
@@ -140,6 +140,18 @@
   </div>
 
   <div class="field">
+    <%= f.label :issn_records -%><br />
+    <%= f.fields_for :issn_records do |issn_record_form| %>
+      <%= render 'issn_record_fields', f: issn_record_form %>
+    <% end %>
+    <div class="links">
+      <p><%= link_to_add_association t('page.add'), f, :issn_records %></p>
+    </div>
+  </div>
+
+  <div class="field">
+    <%= f.label :identifier -%><br />
+  <div class="field">
     <%= f.label :identifier -%><br />
     <%= f.fields_for :identifiers do |identifier_form| %>
       <%= render 'identifier_fields', f: identifier_form %>

--- a/app/views/manifestations/_issn_record_fields.html.erb
+++ b/app/views/manifestations/_issn_record_fields.html.erb
@@ -1,0 +1,4 @@
+<div class="nested-fields">
+  <%= f.text_field :body %>
+  <%= link_to_remove_association t('page.remove'), f, data: {confirm: t('page.are_you_sure')} %><br />
+</div>

--- a/app/views/manifestations/_show_detail_librarian.html.erb
+++ b/app/views/manifestations/_show_detail_librarian.html.erb
@@ -25,8 +25,8 @@
             <td><%= t('activerecord.models.series_statement') -%>:</td>
             <td>
               <%= render 'show_series_detail', manifestation: manifestation %>
-              <%- unless manifestation.identifier_contents(:issn).empty? -%>
-                (<%= t('activerecord.attributes.manifestation.issn') -%>: <%= manifestation.identifier_contents(:issn).join(" ") -%>)
+              <%- unless manifestation.issn_records.empty? -%>
+                (<%= t('activerecord.attributes.manifestation.issn') -%>: <%= manifestation.issn_records.pluck(:body).join(" ") -%>)
               <%- end -%>
             </td>
           </tr>

--- a/app/views/manifestations/_show_detail_user.html.erb
+++ b/app/views/manifestations/_show_detail_user.html.erb
@@ -25,8 +25,8 @@
             <td><%= t('activerecord.models.series_statement') -%>:</td>
             <td>
               <%= render 'show_series_detail', manifestation: manifestation %>
-              <%- unless manifestation.identifier_contents(:issn).empty? -%>
-                (<%= t('activerecord.attributes.manifestation.issn') -%>: <%= manifestation.identifier_contents(:issn).join(" ") -%>)
+              <%- unless manifestation.issn_records.empty? -%>
+                (<%= t('activerecord.attributes.manifestation.issn') -%>: <%= manifestation.issn_records.pluck(:body).join(" ") -%>)
               <%- end -%>
             </td>
           </tr>

--- a/db/migrate/20160319144230_create_issn_records.rb
+++ b/db/migrate/20160319144230_create_issn_records.rb
@@ -1,0 +1,11 @@
+class CreateIssnRecords < ActiveRecord::Migration[6.1]
+  def change
+    create_table :issn_records, comment: 'ISSN' do |t|
+      t.string :body, null: false, comment: 'ISSN'
+
+      t.timestamps
+    end
+
+    add_index :issn_records, :body, unique: true
+  end
+end

--- a/db/migrate/20170116134107_create_issn_record_and_manifestations.rb
+++ b/db/migrate/20170116134107_create_issn_record_and_manifestations.rb
@@ -1,0 +1,12 @@
+class CreateIssnRecordAndManifestations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :issn_record_and_manifestations, comment: '書誌とISSNの関係' do |t|
+      t.references :issn_record, foreign_key: true, null: false
+      t.references :manifestation, foreign_key: true, null: false, index: false
+
+      t.timestamps
+    end
+
+    add_index :issn_record_and_manifestations, [:manifestation_id, :issn_record_id], unique: true, name: 'index_issn_record_and_manifestations_on_manifestation_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -680,6 +680,22 @@ ActiveRecord::Schema.define(version: 2023_08_18_052023) do
     t.index ["user_id"], name: "index_inventory_files_on_user_id"
   end
 
+  create_table "issn_record_and_manifestations", comment: "書誌とISSNの関係", force: :cascade do |t|
+    t.bigint "issn_record_id", null: false
+    t.bigint "manifestation_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["issn_record_id"], name: "index_issn_record_and_manifestations_on_issn_record_id"
+    t.index ["manifestation_id", "issn_record_id"], name: "index_issn_record_and_manifestations_on_manifestation_id", unique: true
+  end
+
+  create_table "issn_records", comment: "ISSN", force: :cascade do |t|
+    t.string "body", null: false, comment: "ISSN"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["body"], name: "index_issn_records_on_body", unique: true
+  end
+
   create_table "item_custom_properties", force: :cascade do |t|
     t.string "name", null: false, comment: "ラベル名"
     t.text "display_name", null: false, comment: "表示名"
@@ -1758,6 +1774,8 @@ ActiveRecord::Schema.define(version: 2023_08_18_052023) do
   add_foreign_key "import_requests", "users"
   add_foreign_key "inventory_files", "shelves"
   add_foreign_key "inventory_files", "users"
+  add_foreign_key "issn_record_and_manifestations", "issn_records"
+  add_foreign_key "issn_record_and_manifestations", "manifestations"
   add_foreign_key "item_custom_values", "item_custom_properties"
   add_foreign_key "item_custom_values", "items"
   add_foreign_key "item_has_use_restrictions", "items"

--- a/spec/fixtures/issn_record_and_manifestations.yml
+++ b/spec/fixtures/issn_record_and_manifestations.yml
@@ -1,0 +1,20 @@
+issn_record_and_manifestation_00001:
+  id: 1
+  manifestation_id: 2
+  issn_record_id: 1
+
+issn_record_and_manifestation_00002:
+  id: 2
+  manifestation_id: 201
+  issn_record_id: 2
+
+# == Schema Information
+#
+# Table name: issn_record_and_manifestations
+#
+#  id               :bigint           not null, primary key
+#  issn_record_id   :bigint           not null
+#  manifestation_id :bigint           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#

--- a/spec/fixtures/issn_records.yml
+++ b/spec/fixtures/issn_records.yml
@@ -1,0 +1,17 @@
+issn_record_00001:
+  id: 1
+  body: 99999999
+
+issn_record_00002:
+  id: 2
+  body: "09130000"
+
+# == Schema Information
+#
+# Table name: issn_records
+#
+#  id         :bigint           not null, primary key
+#  body       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#

--- a/spec/models/loc_search_spec.rb
+++ b/spec/models/loc_search_spec.rb
@@ -125,7 +125,7 @@ describe LocSearch do
       m = LocSearch.import_from_sru_response("00200486")
       expect(m.original_title).to eq "Science and technology of advanced materials"
       expect(m.serial).to be_truthy
-      expect(m.identifier_contents(:issn).first).to eq "14686996"
+      expect(m.issn_records.first.body).to eq "14686996"
       expect(m.identifier_contents(:issn_l).first).to eq "14686996"
       expect(m.frequency.name).to eq "bimonthly"
       series_statement = m.series_statements.first
@@ -137,7 +137,7 @@ describe LocSearch do
       expect(m.original_title).to eq "Superconductor science & technology"
       expect(m.title_alternative).to eq "Supercond. sci. technol ; Superconductor science and technology"
       expect(m.serial).to be_truthy
-      expect(m.identifier_contents(:issn).first).to eq "09532048"
+      expect(m.issn_record.first.body).to eq "09532048"
       expect(m.identifier_contents(:issn_l).first).to eq "09532048"
       expect(m.frequency.name).to eq "monthly"
       series_statement = m.series_statements.first

--- a/spec/models/loc_search_spec.rb
+++ b/spec/models/loc_search_spec.rb
@@ -137,7 +137,7 @@ describe LocSearch do
       expect(m.original_title).to eq "Superconductor science & technology"
       expect(m.title_alternative).to eq "Supercond. sci. technol ; Superconductor science and technology"
       expect(m.serial).to be_truthy
-      expect(m.issn_record.first.body).to eq "09532048"
+      expect(m.issn_records.first.body).to eq "09532048"
       expect(m.identifier_contents(:issn_l).first).to eq "09532048"
       expect(m.frequency.name).to eq "monthly"
       series_statement = m.series_statements.first

--- a/spec/models/resource_import_file_spec.rb
+++ b/spec/models/resource_import_file_spec.rb
@@ -28,7 +28,7 @@ describe ResourceImportFile do
         manifestation.publishers.second.full_name_transcription.should eq 'てすと5'
         manifestation.produces.first.produce_type.name.should eq 'publisher'
         manifestation.creates.first.create_type.name.should eq 'author'
-        manifestation.identifier_contents(:issn).should eq ['03875806']
+        expect(manifestation.issn_records.pluck(:body)).to eq ['03875806']
         Manifestation.count.should eq old_manifestations_count + 10
         Item.count.should eq old_items_count + 10
         Agent.count.should eq old_agents_count + 9


### PR DESCRIPTION
https://github.com/next-l/enju_leaf/pull/1814 と同様に、ISSNを扱うモデルを追加しています。