### PR TITLE
Identifierモデルの移行タスクを追加

### DIFF
--- a/app/models/jpno_record.rb
+++ b/app/models/jpno_record.rb
@@ -1,6 +1,6 @@
 class JpnoRecord < ApplicationRecord
   belongs_to :manifestation
-  validates :body, presence: true
+  validates :body, presence: true, uniqueness: true
   strip_attributes
 end
 

--- a/app/models/ndla_record.rb
+++ b/app/models/ndla_record.rb
@@ -1,6 +1,6 @@
 class NdlaRecord < ApplicationRecord
   belongs_to :agent
-  validates :body, presence: true
+  validates :body, presence: true, uniqueness: true
 end
 
 # == Schema Information

--- a/lib/tasks/enju_leaf_tasks.rake
+++ b/lib/tasks/enju_leaf_tasks.rake
@@ -85,4 +85,71 @@ namespace :enju_leaf do
       migrate_attachment
     end
   end
+
+  desc 'Migrate identifiers'
+  task :migrate_identifiers => :environment do
+    isbn = IdentifierType.find_by(name: 'isbn')
+    Identifier.where(identifier_type: isbn).find_each do |identifier|
+      IsbnRecordAndManifestation.create(
+        manifestation: identifier.manifestation,
+        isbn_record: IsbnRecord.find_by(body: identifier.body)
+      )
+    end
+
+    issn = IdentifierType.find_by(name: 'issn')
+    Identifier.where(identifier_type: issn).find_each do |identifier|
+      IssnRecordAndManifestation.create(
+        manifestation: identifier.manifestation,
+        issn_record: IssnRecord.find_by(body: identifier.body)
+      )
+    end
+
+    issn_l = IdentifierType.find_by(name: 'issn_l')
+    Identifier.where(identifier_type: issn).find_each do |identifier|
+      IssnRecordAndManifestation.create(
+        manifestation: identifier.manifestation,
+        issn_record: IssnRecord.find_by(body: identifier.body)
+      )
+    end
+
+    jpno = IdentifierType.find_by(name: 'jpno')
+    Identifier.where(identifier_type: jpno).find_each do |identifier|
+      JpnoRecord.create(
+        manifestation: identifier.manifestation,
+        body: identifier.body
+      )
+    end
+
+    iss_itemno = IdentifierType.find_by(name: 'iss_itemno')
+    Identifier.where(identifier_type: jpno).find_each do |identifier|
+      NdiBibIdRecord.create(
+        manifestation: identifier.manifestation,
+        body: identifier.body
+      )
+    end
+
+    ncid = IdentifierType.find_by(name: 'ncid')
+    Identifier.where(identifier_type: ncid).find_each do |identifier|
+      NcidRecord.create(
+        manifestation: identifier.manifestation,
+        body: identifier.body
+      )
+    end
+
+    lccn = IdentifierType.find_by(name: 'lccn')
+    Identifier.where(identifier_type: lccn).find_each do |identifier|
+      LccnRecord.create(
+        manifestation: identifier.manifestation,
+        body: identifier.body
+      )
+    end
+
+    doi = IdentifierType.find_by(name: 'doi')
+    Identifier.where(identifier_type: doi).find_each do |identifier|
+      DoiRecord.create(
+        manifestation: identifier.manifestation,
+        body: identifier.body
+      )
+    end
+  end
 end

--- a/lib/tasks/enju_leaf_tasks.rake
+++ b/lib/tasks/enju_leaf_tasks.rake
@@ -88,68 +88,56 @@ namespace :enju_leaf do
 
   desc 'Migrate identifiers'
   task :migrate_identifiers => :environment do
-    isbn = IdentifierType.find_by(name: 'isbn')
-    Identifier.where(identifier_type: isbn).find_each do |identifier|
-      IsbnRecordAndManifestation.create(
-        manifestation: identifier.manifestation,
-        isbn_record: IsbnRecord.find_by(body: identifier.body)
-      )
-    end
+    IdentifierType.find_each do |identifier_type|
+      Identifier.where(identifier_type: identifier_type).find_each do |identifier|
+        Manifestation.transaction do
+          case identifier_type.name
+          when 'isbn'
+            IsbnRecordAndManifestation.create(
+              manifestation: identifier.manifestation,
+              isbn_record: IsbnRecord.find_by(body: identifier.body)
+            )
+          when 'issn'
+            IssnRecordAndManifestation.create(
+              manifestation: identifier.manifestation,
+              issn_record: IssnRecord.find_by(body: identifier.body)
+            )
+          when 'issn_l'
+            IssnRecordAndManifestation.create(
+              manifestation: identifier.manifestation,
+              issn_record: IssnRecord.find_by(body: identifier.body)
+            )
+          when 'jpno'
+            JpnoRecord.create(
+              manifestation: identifier.manifestation,
+              body: identifier.body
+            )
+          when 'iss_itemno'
+            NdlBibIdRecord.create(
+              manifestation: identifier.manifestation,
+              body: identifier.body
+            )
+          when 'ncid'
+            NcidRecord.create(
+              manifestation: identifier.manifestation,
+              body: identifier.body
+            )
+          when 'lccn'
+            LccnRecord.create(
+              manifestation: identifier.manifestation,
+              body: identifier.body
+            )
+          when 'doi'
+            DoiRecord.create(
+              manifestation: identifier.manifestation,
+              body: identifier.body
+            )
+          end
 
-    issn = IdentifierType.find_by(name: 'issn')
-    Identifier.where(identifier_type: issn).find_each do |identifier|
-      IssnRecordAndManifestation.create(
-        manifestation: identifier.manifestation,
-        issn_record: IssnRecord.find_by(body: identifier.body)
-      )
-    end
-
-    issn_l = IdentifierType.find_by(name: 'issn_l')
-    Identifier.where(identifier_type: issn).find_each do |identifier|
-      IssnRecordAndManifestation.create(
-        manifestation: identifier.manifestation,
-        issn_record: IssnRecord.find_by(body: identifier.body)
-      )
-    end
-
-    jpno = IdentifierType.find_by(name: 'jpno')
-    Identifier.where(identifier_type: jpno).find_each do |identifier|
-      JpnoRecord.create(
-        manifestation: identifier.manifestation,
-        body: identifier.body
-      )
-    end
-
-    iss_itemno = IdentifierType.find_by(name: 'iss_itemno')
-    Identifier.where(identifier_type: jpno).find_each do |identifier|
-      NdiBibIdRecord.create(
-        manifestation: identifier.manifestation,
-        body: identifier.body
-      )
-    end
-
-    ncid = IdentifierType.find_by(name: 'ncid')
-    Identifier.where(identifier_type: ncid).find_each do |identifier|
-      NcidRecord.create(
-        manifestation: identifier.manifestation,
-        body: identifier.body
-      )
-    end
-
-    lccn = IdentifierType.find_by(name: 'lccn')
-    Identifier.where(identifier_type: lccn).find_each do |identifier|
-      LccnRecord.create(
-        manifestation: identifier.manifestation,
-        body: identifier.body
-      )
-    end
-
-    doi = IdentifierType.find_by(name: 'doi')
-    Identifier.where(identifier_type: doi).find_each do |identifier|
-      DoiRecord.create(
-        manifestation: identifier.manifestation,
-        body: identifier.body
-      )
+          identifier.destroy
+          Rails.logger.info "#{identifier_type.name} #{identifier.body} migrated"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
```
bundle exec rake enju_leaf:migrate_identifiers
```

移行対象は以下です。

* isbn -> IsbnRecord
* issn, issn_l -> IssnRecord
* ncid -> NcidRecord
* lccn -> LccnRecord
* iss_itemno -> NdlBibIdRecord
* jpno -> JpnoRecord
* doi -> DoiRecord