### PR TITLE
ローカル環境でのsystem specのエラーを修正

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,6 +4,7 @@ services:
   web:
     environment:
       - WEBPACKER_DEV_SERVER_HOST=webpacker
+      - SELENIUM_DRIVER_URL=http://selenium:4444/wd/hub
 
   selenium:
     image: selenium/standalone-chrome:114.0

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -15,8 +15,12 @@ end
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
-    Capybara.app_host = "http://#{Capybara.server_host}"
-    driven_by :remote_chrome
+    if ENV['SELENIUM_DRIVER_URL']
+      Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
+      Capybara.app_host = "http://#{Capybara.server_host}"
+      driven_by :remote_chrome
+    else
+      driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+    end
   end
 end


### PR DESCRIPTION
環境変数`SELENIUM_DRIVER_URL`の有無で、使用するドライバーを分けるようにしています。