### PR TITLE
redisコンテナに"restart: always"オプションを追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,7 @@ services:
       internal:
     expose:
       - 6379
+    restart: always
     healthcheck:
       test: ["CMD-SHELL", "redis-cli ping"]
       interval: 30s


### PR DESCRIPTION
他のコンテナには同オプションが指定されていたのですが、redisだけ抜けていました。