### PR TITLE
rails db:seedコマンドの中でrake enju_leaf:setupタスクを実行

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,6 +17,8 @@ def new_profile
   profile
 end
 
+Rake::Task['enju_leaf:setup'].invoke
+
 system_user = User.new
 system_user.username = 'system'
 system_user.password = SecureRandom.urlsafe_base64(32)


### PR DESCRIPTION
データベースの初期化コマンド`rails db:prepare`を実行できるようにするため。このコマンドで、データベースの作成と`rails db:seed`コマンドをまとめて実行できる。
https://railsguides.jp/active_record_migrations.html#%E3%83%87%E3%83%BC%E3%82%BF%E3%83%99%E3%83%BC%E3%82%B9%E3%82%92%E6%BA%96%E5%82%99%E3%81%99%E3%82%8B

インストールの手順も修正すること。