### PR TITLE
libvips42をインストール

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           bundler-cache: true
       - name: Install dependencies
-        run: yarn install
+        run: yarn install && sudo apt-get install libvips42
       # Add or replace test runners here
       - name: Start containers
         run: cp .env.test.ci .env.test && cp .env.test .env && cp docker-compose.ci.yml docker-compose.override.yml && docker-compose up -d solr tika

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN mkdir -p /etc/apt/keyrings && \
   curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /etc/apt/keyrings/yarnkey.gpg && \
   echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
   echo "deb [signed-by=/etc/apt/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-  apt-get update -qq && apt-get install -y nodejs yarn postgresql-client imagemagick poppler-utils ffmpeg && apt-get clean && rm -rf /var/lib/apt/lists/*
+  apt-get update -qq && apt-get install -y nodejs yarn postgresql-client imagemagick poppler-utils ffmpeg libvips42 && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN mkdir /enju && chown -R enju:enju /enju
 USER enju
 WORKDIR /enju

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ Bundler.require(*Rails.groups)
 module EnjuLeaf
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.1
+    config.load_defaults 7.0
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
Rails 7.0では、Active Storageでの画像変換でlibvipsを使用するようになっている。
https://railsguides.jp/v7.0/upgrading_ruby_on_rails.html#active-storage%E3%81%AE%E3%83%87%E3%83%95%E3%82%A9%E3%83%AB%E3%83%88%E3%81%AE%E3%83%90%E3%83%AA%E3%82%A2%E3%83%B3%E3%83%88%E3%83%97%E3%83%AD%E3%82%BB%E3%83%83%E3%82%B5%E3%81%8C-vips%E3%81%AB%E5%A4%89%E6%9B%B4