### PR TITLE
NDLサーチの書誌IDが'-00'で終わる場合、NDLサーチのリンク先にiss.ndl.go.jpを使用

### DIFF
--- a/app/helpers/enju_biblio/application_helper.rb
+++ b/app/helpers/enju_biblio/application_helper.rb
@@ -57,7 +57,11 @@ module EnjuBiblio
       when 'doi'
         link_to identifier.body, "https://doi.org/#{identifier.body}"
       when 'iss_itemno'
-        link_to identifier.body, "https://ndlsearch.ndl.go.jp/books/#{identifier.body}"
+        if identifier.body =~ /\AR[0-9A-Za-z]+?-I[0-9A-Za-z]+?-00\z/
+          link_to identifier.body, "https://iss.ndl.go.jp/books/#{identifier.body}"
+        else
+          link_to identifier.body, "https://ndlsearch.ndl.go.jp/books/#{identifier.body}"
+        end
       when 'lccn'
         link_to identifier.body, "https://lccn.loc.gov/#{identifier.body}"
       when 'ncid'

--- a/spec/factories/identifiers.rb
+++ b/spec/factories/identifiers.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :identifier do
     sequence(:body){|n| "identifier_body_#{n}"}
-    identifier_type_id{FactoryBot.create(:identifier_type).id}
-    association(:manifestation)
+    association :identifier_type
+    association :manifestation
   end
 end
 

--- a/spec/helpers/enju_biblio/application_helper_spec.rb
+++ b/spec/helpers/enju_biblio/application_helper_spec.rb
@@ -7,7 +7,31 @@ describe EnjuBiblio::ApplicationHelper do
     expect(helper.form_icon(nil)).to match /src=\"\/assets\/icons\/help-/
   end
 
-  it "should render form_icon if carrier_type's attachment is blank " do
+  it "should render form_icon if carrier_type's attachment is blank" do
     expect(helper.form_icon(FactoryBot.create(:carrier_type))).to match /src=\"\/assets\/icons\/help-/
+  end
+
+  it "should link to old NDL search if iss_itemno ends with '-00'" do
+    expect(
+      helper.identifier_link(
+        FactoryBot.build(
+          :identifier,
+          body: 'R100000039-I001413988-00',
+          identifier_type: IdentifierType.find_by(name: 'iss_itemno')
+        )
+      )
+    ).to eq "<a href=\"https://iss.ndl.go.jp/books/R100000039-I001413988-00\">R100000039-I001413988-00</a>"
+  end
+
+  it "should link to new NDL search if iss_itemno doesn't end with '-00'" do
+    expect(
+      helper.identifier_link(
+        FactoryBot.build(
+          :identifier,
+          body: 'R100000039-I001413988',
+          identifier_type: IdentifierType.find_by(name: 'iss_itemno')
+        )
+      )
+    ).to eq "<a href=\"https://ndlsearch.ndl.go.jp/books/R100000039-I001413988\">R100000039-I001413988</a>"
   end
 end


### PR DESCRIPTION
https://github.com/next-l/enju_leaf/issues/1855 の対応。
NDLサーチの書誌ID`R100000039-I001413988-00`は、`R100000039-I3377584`に付け替えられているが、ホスト名を`iss.ndl.go.jp`にすれば、新しいIDにリダイレクトされる。つまり、今までにEnjuにインポートされたNDLサーチの書誌IDがリンク切れになることはない。
https://iss.ndl.go.jp/books/R100000039-I001413988-00

しかし、1.4.4では古いIDもリンク先が`ndlsearch.ndl.go.jp`を使用していた。このPRでは、`-00`で終わる書誌IDについては、リンク先に`iss.ndl.go.jp`を使用するようにしている。