### PR TITLE
書棚ごとの冊数の表示にcounter_cacheを使用しないよう変更

### DIFF
--- a/app/views/libraries/show.html.erb
+++ b/app/views/libraries/show.html.erb
@@ -83,7 +83,7 @@
                   })
                 </script>
               </td>
-              <td><%= shelf.items_count -%></td>
+              <td><%= shelf.items.count -%></td>
               <td><%= shelf.note -%></td>
             </tr>
           <%- end -%>

--- a/spec/system/libraries_spec.rb
+++ b/spec/system/libraries_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Libraries', type: :system do
 
     it 'should show shelves' do
       visit library_path(libraries(:library_00002).id, locale: :ja, anchor: 'tab3')
-      expect(find(:xpath, '//div[@id="tab3"]')).to have_content "First shelf 0\nSecond shelf 0"
+      expect(find(:xpath, '//div[@id="tab3"]')).to have_content "First shelf 4\nSecond shelf 0"
     end
   end
 


### PR DESCRIPTION
https://github.com/next-l/enju_leaf/issues/1871 の修正です。