### PR TITLE
most_recentカラムの移行を修正

### DIFF
--- a/app/models/agent_import_file.rb
+++ b/app/models/agent_import_file.rb
@@ -37,6 +37,10 @@ class AgentImportFile < ApplicationRecord
 
   attr_accessor :mode
 
+  def self.transition_class
+    AgentImportFileTransition
+  end
+
   def state_machine
     AgentImportFileStateMachine.new(self, transition_class: AgentImportFileTransition)
   end

--- a/app/models/event_export_file.rb
+++ b/app/models/event_export_file.rb
@@ -21,6 +21,10 @@ class EventExportFile < ApplicationRecord
   validates_attachment_content_type :event_export, content_type: /\Atext\/plain\Z/
   has_many :event_export_file_transitions, autosave: false, dependent: :destroy
 
+  def self.transition_class
+    EventExportFileTransition
+  end
+
   def state_machine
     EventExportFileStateMachine.new(self, transition_class: EventExportFileTransition)
   end

--- a/app/models/event_import_file.rb
+++ b/app/models/event_import_file.rb
@@ -37,6 +37,10 @@ class EventImportFile < ApplicationRecord
 
   attr_accessor :mode
 
+  def self.transition_class
+    EventImportFileTransition
+  end
+
   def state_machine
     EventImportFileStateMachine.new(self, transition_class: EventImportFileTransition)
   end

--- a/app/models/import_request.rb
+++ b/app/models/import_request.rb
@@ -13,6 +13,10 @@ class ImportRequest < ApplicationRecord
 
   has_many :import_request_transitions, autosave: false, dependent: :destroy
 
+  def self.transition_class
+    ImportRequestTransition
+  end
+
   def state_machine
     ImportRequestStateMachine.new(self, transition_class: ImportRequestTransition)
   end

--- a/app/models/manifestation_checkout_stat.rb
+++ b/app/models/manifestation_checkout_stat.rb
@@ -15,6 +15,10 @@ class ManifestationCheckoutStat < ApplicationRecord
 
   has_many :manifestation_checkout_stat_transitions, autosave: false, dependent: :destroy
 
+  def self.transition_class
+    ManifestationCheckoutStatTransition
+  end
+
   def state_machine
     ManifestationCheckoutStatStateMachine.new(self, transition_class: ManifestationCheckoutStatTransition)
   end

--- a/app/models/manifestation_reserve_stat.rb
+++ b/app/models/manifestation_reserve_stat.rb
@@ -15,6 +15,10 @@ class ManifestationReserveStat < ApplicationRecord
 
   has_many :manifestation_reserve_stat_transitions, autosave: false, dependent: :destroy
 
+  def self.transition_class
+    ManifestationReserveStatTransition
+  end
+
   def state_machine
     ManifestationReserveStatStateMachine.new(self, transition_class: ManifestationReserveStatTransition)
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -36,6 +36,10 @@ class Message < ApplicationRecord
   paginates_per 10
   has_many :message_transitions, autosave: false, dependent: :destroy
 
+  def self.transition_class
+    MessageTransition
+  end
+
   def state_machine
     @state_machine ||= MessageStateMachine.new(self, transition_class: MessageTransition)
   end

--- a/app/models/reserve.rb
+++ b/app/models/reserve.rb
@@ -64,6 +64,10 @@ class Reserve < ApplicationRecord
 
   paginates_per 10
 
+  def self.transition_class
+    ReserveTransition
+  end
+
   def state_machine
     ReserveStateMachine.new(self, transition_class: ReserveTransition)
   end

--- a/app/models/resource_export_file.rb
+++ b/app/models/resource_export_file.rb
@@ -23,6 +23,10 @@ class ResourceExportFile < ApplicationRecord
 
   has_many :resource_export_file_transitions, autosave: false, dependent: :destroy
 
+  def self.transition_class
+    ResourceExportFileTransition
+  end
+
   def state_machine
     ResourceExportFileStateMachine.new(self, transition_class: ResourceExportFileTransition)
   end

--- a/app/models/resource_import_file.rb
+++ b/app/models/resource_import_file.rb
@@ -38,6 +38,10 @@ class ResourceImportFile < ApplicationRecord
 
   attr_accessor :mode, :library_id
 
+  def self.transition_class
+    ResourceImportFileTransition
+  end
+
   def state_machine
     ResourceImportFileStateMachine.new(self, transition_class: ResourceImportFileTransition)
   end

--- a/app/models/user_checkout_stat.rb
+++ b/app/models/user_checkout_stat.rb
@@ -15,6 +15,10 @@ class UserCheckoutStat < ApplicationRecord
 
   has_many :user_checkout_stat_transitions, autosave: false, dependent: :destroy
 
+  def self.transition_class
+    UserCheckoutStatTransition
+  end
+
   def state_machine
     UserCheckoutStatStateMachine.new(self, transition_class: UserCheckoutStatTransition)
   end

--- a/app/models/user_export_file.rb
+++ b/app/models/user_export_file.rb
@@ -22,6 +22,10 @@ class UserExportFile < ApplicationRecord
 
   has_many :user_export_file_transitions, autosave: false, dependent: :destroy
 
+  def self.transition_class
+    UserExportFileTransition
+  end
+
   def state_machine
     UserExportFileStateMachine.new(self, transition_class: UserExportFileTransition)
   end

--- a/app/models/user_import_file.rb
+++ b/app/models/user_import_file.rb
@@ -38,6 +38,10 @@ class UserImportFile < ApplicationRecord
 
   attr_accessor :mode
 
+  def self.transition_class
+    UserImportFileTransition
+  end
+
   def state_machine
     UserImportFileStateMachine.new(self, transition_class: UserImportFileTransition)
   end

--- a/app/models/user_reserve_stat.rb
+++ b/app/models/user_reserve_stat.rb
@@ -15,6 +15,10 @@ class UserReserveStat < ApplicationRecord
 
   has_many :user_reserve_stat_transitions, autosave: false, dependent: :destroy
 
+  def self.transition_class
+    UserReserveStatTransition
+  end
+
   def state_machine
     UserReserveStatStateMachine.new(self, transition_class: UserReserveStatTransition)
   end

--- a/lib/tasks/enju_biblio_tasks.rake
+++ b/lib/tasks/enju_biblio_tasks.rake
@@ -26,10 +26,11 @@ namespace :enju_biblio do
 
   desc "upgrade enju_biblio"
   task upgrade: :environment do
-    Rake::Task['statesman:backfill_most_recent'].invoke('AgentImportFile')
-    Rake::Task['statesman:backfill_most_recent'].invoke('ImportRequest')
-    Rake::Task['statesman:backfill_most_recent'].invoke('ResourceExportFile')
-    Rake::Task['statesman:backfill_most_recent'].invoke('ResourceImportFile')
+    %w(AgentImportFile ImportRequest ResourceExportFile ResourceImportFile).each do |klass|
+      Rake::Task['statesman:backfill_most_recent'].invoke(klass)
+      Rake::Task['statesman:backfill_most_recent'].reenable
+    end
+
     update_carrier_type
     puts 'enju_biblio: The upgrade completed successfully.'
   end

--- a/lib/tasks/enju_circulation_tasks.rake
+++ b/lib/tasks/enju_circulation_tasks.rake
@@ -39,11 +39,10 @@ namespace :enju_circulation do
 
   desc "upgrade enju_circulation"
   task upgrade: :environment do
-    Rake::Task['statesman:backfill_most_recent'].invoke('ManifestationCheckoutStat')
-    Rake::Task['statesman:backfill_most_recent'].invoke('ManifestationReserveStat')
-    Rake::Task['statesman:backfill_most_recent'].invoke('UserCheckoutStat')
-    Rake::Task['statesman:backfill_most_recent'].invoke('UserReserveStat')
-    Rake::Task['statesman:backfill_most_recent'].invoke('Reserve')
+    %w(ManifestationCheckoutStat ManifestationReserveStat UserCheckoutStat UserReserveStat Reserve).each do |klass|
+      Rake::Task['statesman:backfill_most_recent'].invoke(klass)
+      Rake::Task['statesman:backfill_most_recent'].reenable
+    end
     puts 'enju_circulation: The upgrade completed successfully.'
   end
 

--- a/lib/tasks/enju_event_tasks.rake
+++ b/lib/tasks/enju_event_tasks.rake
@@ -14,7 +14,9 @@ namespace :enju_event do
 
   desc "upgrade enju_circulation"
   task upgrade: :environment do
-    Rake::Task['statesman:backfill_most_recent'].invoke('EventExportFile')
-    Rake::Task['statesman:backfill_most_recent'].invoke('EventImportFile')
+    %w(EventExportFile EventImportFile).each do |klass|
+      Rake::Task['statesman:backfill_most_recent'].invoke(klass)
+      Rake::Task['statesman:backfill_most_recent'].reenable
+    end
   end
 end

--- a/lib/tasks/enju_leaf_tasks.rake
+++ b/lib/tasks/enju_leaf_tasks.rake
@@ -59,6 +59,8 @@ namespace :enju_leaf do
 
   desc 'Backfill migration versions before Next-L Enju Leaf 1.4'
   task :backfill_migration_versions => :environment do
+    Rake::Task['enju_leaf:upgrade'].invoke
+
     Dir.glob(Rails.root.join('db/migrate/*.rb')).each do |file|
 			entry = File.basename(file).split('_', 3)
       table_name = entry[2].gsub(/\.rb\z/, '')
@@ -78,6 +80,44 @@ namespace :enju_leaf do
       # enju_news
       next if [
         20081031033632, 20090126071155, 20110220103937
+      ].include?(version)
+
+      # enju_biblio
+      next if [
+        20170116150432, 20180107161347, 20180107161410,
+        20200425072340, 20200425072349, 20200425074758, 20200425074822
+      ].include?(version)
+
+      # enju_ndl
+      next if [
+        20171126072934, 20190501043418
+      ].include?(version)
+
+      # enju_inventory
+      next if [
+        20081117143156, 20081117143455, 20090706125521,
+        20120413100431, 20191224083828, 20191224091957, 20191230082846
+      ].include?(version)
+
+      # enju_event
+      next if [
+        20180107164558, 20180107164617
+      ].include?(version)
+
+      # enju_circulation
+      next if [
+        20180107161035, 20180107161951, 20180107162009,
+        20180107162029, 20180107162048
+      ].include?(version)
+
+      # enju_seed
+      next if [
+        20180107160726, 20180107160740
+      ].include?(version)
+
+      # enju_message
+      next if [
+        20180107162659
       ].include?(version)
 
       next if ActiveRecord::Base.connection.exec_query('SELECT version FROM schema_migrations WHERE version = $1', 'SQL', [[nil, version]]).first

--- a/lib/tasks/enju_library_tasks.rake
+++ b/lib/tasks/enju_library_tasks.rake
@@ -19,8 +19,11 @@ namespace :enju_library do
 
   desc "upgrade enju_library"
   task :upgrade => :environment do
-    Rake::Task['statesman:backfill_most_recent'].invoke('UserExportFile')
-    Rake::Task['statesman:backfill_most_recent'].invoke('UserImportFile')
+    %w(UserExportFile UserImportFile).each do |klass|
+      Rake::Task['statesman:backfill_most_recent'].invoke(klass)
+      Rake::Task['statesman:backfill_most_recent'].reenable
+    end
+
     library_group = LibraryGroup.site_config
     library_group.user = User.find(1)
     login_ja = <<"EOS"

--- a/lib/tasks/enju_message_tasks.rake
+++ b/lib/tasks/enju_message_tasks.rake
@@ -3,7 +3,11 @@ require 'active_record/fixtures'
 namespace :enju_message do
   desc "upgrade enju_message"
   task upgrade: :environment do
-    Rake::Task['statesman:backfill_most_recent'].invoke('Message')
+    %w(Message).each do |klass|
+      Rake::Task['statesman:backfill_most_recent'].invoke(klass)
+      Rake::Task['statesman:backfill_most_recent'].reenable
+    end
+
     puts 'enju_message: The upgrade completed successfully.'
   end
 end


### PR DESCRIPTION
`statesman:backfill_most_recent`タスクが正常に実行されていなかったのを修正しています。

rakeタスク内で同名のタスクを呼び出すには、`Rake::Task#reenable`を使用する必要がある。
https://qiita.com/yokozawa/items/c7ff1f5131cefd3f6aea