### PR TITLE
sunspot 2.7に更新

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ end
 
 gem 'devise'
 gem 'pundit'
-gem 'sunspot_rails'
+gem 'sunspot_rails', '~> 2.7'
 gem 'kt-paperclip'
 gem 'acts_as_list'
 gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,7 +381,7 @@ GEM
       xml-mapping_extensions (~> 0.4, >= 0.4.8)
     rexml (3.2.8)
       strscan (>= 3.0.9)
-    rsolr (2.6.0)
+    rsolr (2.5.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
     rspec-core (3.13.0)
@@ -450,12 +450,13 @@ GEM
     strip_attributes (1.13.0)
       activemodel (>= 3.0, < 8.0)
     strscan (3.1.0)
-    sunspot (2.6.0)
+    sunspot (2.7.0)
+      bigdecimal
       pr_geohash (~> 1.0)
-      rsolr (>= 1.1.1, < 3)
-    sunspot_rails (2.6.0)
-      rails (>= 3)
-      sunspot (= 2.6.0)
+      rsolr (>= 1.1.1, < 2.6)
+    sunspot_rails (2.7.0)
+      rails (>= 5)
+      sunspot (= 2.7.0)
     sxp (2.0.0)
       matrix (~> 0.4)
       rdf (~> 3.3)
@@ -561,7 +562,7 @@ DEPENDENCIES
   sprockets-rails
   statesman (~> 12.1)
   strip_attributes
-  sunspot_rails
+  sunspot_rails (~> 2.7)
   tzinfo-data
   vcr
   web-console


### PR DESCRIPTION
Ruby 3.2以上のテストが追加されているとのこと。
https://github.com/sunspot/sunspot/releases/tag/v2.7.0