### PR TITLE
画像のフォームに"accept: 'image/*'"を追加

### DIFF
--- a/app/views/carrier_types/_form.html.erb
+++ b/app/views/carrier_types/_form.html.erb
@@ -11,7 +11,7 @@
   </div>
   <div class="field">
     <%= f.label t('page.file') -%>
-    <%= f.file_field :attachment -%>
+    <%= f.file_field :attachment, accept: 'image/*' -%>
   </div>
 
   <% if f.object.attachment.present? %>

--- a/app/views/library_groups/_form.html.erb
+++ b/app/views/library_groups/_form.html.erb
@@ -13,7 +13,7 @@
 
   <div class="field">
     <%= f.label :header_logo -%><br />
-    <%= f.file_field :header_logo -%>
+    <%= f.file_field :header_logo, accept: 'image/*' -%>
     <br />
     <%= f.check_box :delete_header_logo -%>
     <%= t('page.destroy') %>

--- a/app/views/picture_files/_form.html.erb
+++ b/app/views/picture_files/_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_with(model: picture_file) do |f| -%>
+  <%= error_messages(picture_file) -%>
+
+  <div class="field">
+    <%= f.label t('page.file') -%><br />
+    <%= f.file_field :attachment, accept: 'image/*', required: true -%>
+  </div>
+
+  <% if picture_file.attachment.attached? %>
+    <div class="field">
+      <%= render 'picture_files/link', picture_file: picture_file %>
+    </div>
+  <% end %>
+
+  <%= f.hidden_field :picture_attachable_id -%>
+  <%= f.hidden_field :picture_attachable_type -%>
+
+  <div class="actions">
+    <%= f.submit %>
+  </div>
+<%- end -%>

--- a/app/views/picture_files/edit.html.erb
+++ b/app/views/picture_files/edit.html.erb
@@ -1,24 +1,7 @@
 <div id="content_detail" class="ui-corner-all ui-widget-content">
   <h1 class="title"><%= t('page.editing', model: t('activerecord.models.picture_file')) -%></h1>
   <div id="content_list">
-
-  <%= form_with(model: @picture_file) do |f| -%>
-    <%= error_messages(@picture_file) -%>
-
-    <div class="field">
-      <%= f.label t('page.file') -%><br />
-      <%= f.file_field :attachment -%>
-    </div>
-
-    <div class="field">
-      <%= render 'picture_files/link', picture_file: @picture_file %>
-    </div>
-
-    <div class="actions">
-      <%= f.submit %>
-    </div>
-  <%- end -%>
-
+    <%= render 'form', picture_file: @picture_file %>
   </div>
 </div>
 

--- a/app/views/picture_files/new.html.erb
+++ b/app/views/picture_files/new.html.erb
@@ -1,29 +1,8 @@
 <div id="content_detail" class="ui-corner-all ui-widget-content">
-<h1 class="title"><%= t('page.new', model: t('activerecord.models.picture_file')) -%></h1>
-<div id="content_list">
-
-<%= form_with(model: @picture_file) do |f| -%>
-  <% if @picture_file.errors.any? %>
-    <div id="error_explanation">
-      <ul>
-        <li><%= t('picture_file.invalid_file') %></li>
-      </ul>
-    </div>
-  <% end %>
-
-  <%= f.hidden_field :picture_attachable_id -%>
-  <%= f.hidden_field :picture_attachable_type -%>
-
-  <div class="field">
-    <%= f.label t('page.file') -%><br />
-    <%= f.file_field :attachment -%>
+  <h1 class="title"><%= t('page.new', model: t('activerecord.models.picture_file')) -%></h1>
+  <div id="content_list">
+    <%= render 'form', picture_file: @picture_file %>
   </div>
-
-  <div class="actions">
-    <%= f.submit %>
-  </div>
-<%- end -%>
-</div>
 </div>
 
 <div id="submenu" class="ui-corner-all ui-widget-content">


### PR DESCRIPTION
一部のファイルアップロード用のフォームで、選択対象を画像ファイルに限定しています。