### PR TITLE
ヘルスチェックエンドポイントを有効化

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,6 +166,13 @@ Rails.application.routes.draw do
   get '/page/system_information' => 'page#system_information'
   get '/page/routing_error' => 'page#routing_error'
   match 'oai', to: "oai#index", via: [:get, :post]
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+
+  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
+  # Can be used by load balancers and uptime monitors to verify that the app is live.
+  get "up" => "rails/health#show", as: :rails_health_check
+
+  # Defines the root path route ("/")
   root :to => "page#index"
 end


### PR DESCRIPTION
Rails組み込みのヘルスチェックエンドポイントを有効化しています。`/up`でステータスコード200か500を返します。
https://railsguides.jp/v7.1/action_controller_overview.html#%E7%B5%84%E3%81%BF%E8%BE%BC%E3%81%BF%E3%81%AE%E3%83%98%E3%83%AB%E3%82%B9%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%82%A8%E3%83%B3%E3%83%89%E3%83%9D%E3%82%A4%E3%83%B3%E3%83%88