### PR TITLE
statesman gemで使用しているmetadataカラムをJSONB型に変換

### DIFF
--- a/app/models/agent_import_file_transition.rb
+++ b/app/models/agent_import_file_transition.rb
@@ -1,7 +1,4 @@
 class AgentImportFileTransition < ApplicationRecord
-  include Statesman::Adapters::ActiveRecordTransition
-
-  
   belongs_to :agent_import_file, inverse_of: :agent_import_file_transitions
 end
 
@@ -11,7 +8,7 @@ end
 #
 #  id                   :bigint           not null, primary key
 #  to_state             :string
-#  metadata             :text             default({})
+#  metadata             :jsonb            not null
 #  sort_key             :integer
 #  agent_import_file_id :bigint
 #  created_at           :datetime         not null

--- a/app/models/bookmark_stat_transition.rb
+++ b/app/models/bookmark_stat_transition.rb
@@ -1,7 +1,4 @@
 class BookmarkStatTransition < ApplicationRecord
-  include Statesman::Adapters::ActiveRecordTransition
-
-
   belongs_to :bookmark_stat, inverse_of: :bookmark_stat_transitions
 end
 
@@ -11,7 +8,7 @@ end
 #
 #  id               :bigint           not null, primary key
 #  to_state         :string
-#  metadata         :text             default({})
+#  metadata         :jsonb            not null
 #  sort_key         :integer
 #  bookmark_stat_id :bigint
 #  created_at       :datetime         not null

--- a/app/models/event_export_file_transition.rb
+++ b/app/models/event_export_file_transition.rb
@@ -1,7 +1,4 @@
 class EventExportFileTransition < ApplicationRecord
-  include Statesman::Adapters::ActiveRecordTransition
-
-
   belongs_to :event_export_file, inverse_of: :event_export_file_transitions
 end
 
@@ -11,7 +8,7 @@ end
 #
 #  id                   :bigint           not null, primary key
 #  to_state             :string
-#  metadata             :text             default({})
+#  metadata             :text             default("{}")
 #  sort_key             :integer
 #  event_export_file_id :bigint
 #  created_at           :datetime         not null

--- a/app/models/event_export_file_transition.rb
+++ b/app/models/event_export_file_transition.rb
@@ -8,7 +8,7 @@ end
 #
 #  id                   :bigint           not null, primary key
 #  to_state             :string
-#  metadata             :text             default("{}")
+#  metadata             :jsonb            not null
 #  sort_key             :integer
 #  event_export_file_id :bigint
 #  created_at           :datetime         not null

--- a/app/models/event_import_file_transition.rb
+++ b/app/models/event_import_file_transition.rb
@@ -1,7 +1,4 @@
 class EventImportFileTransition < ApplicationRecord
-  include Statesman::Adapters::ActiveRecordTransition
-
-
   belongs_to :event_import_file, inverse_of: :event_import_file_transitions
 end
 
@@ -11,7 +8,7 @@ end
 #
 #  id                   :bigint           not null, primary key
 #  to_state             :string
-#  metadata             :text             default({})
+#  metadata             :jsonb            not null
 #  sort_key             :integer
 #  event_import_file_id :bigint
 #  created_at           :datetime         not null

--- a/app/models/import_request_transition.rb
+++ b/app/models/import_request_transition.rb
@@ -1,7 +1,4 @@
 class ImportRequestTransition < ApplicationRecord
-  include Statesman::Adapters::ActiveRecordTransition
-
-  
   belongs_to :import_request, inverse_of: :import_request_transitions
 end
 
@@ -11,7 +8,7 @@ end
 #
 #  id                :bigint           not null, primary key
 #  to_state          :string
-#  metadata          :text             default({})
+#  metadata          :jsonb            not null
 #  sort_key          :integer
 #  import_request_id :bigint
 #  created_at        :datetime         not null

--- a/app/models/manifestation_checkout_stat_transition.rb
+++ b/app/models/manifestation_checkout_stat_transition.rb
@@ -1,7 +1,4 @@
 class ManifestationCheckoutStatTransition < ApplicationRecord
-  include Statesman::Adapters::ActiveRecordTransition
-
-  
   belongs_to :manifestation_checkout_stat, inverse_of: :manifestation_checkout_stat_transitions
 end
 
@@ -11,7 +8,7 @@ end
 #
 #  id                             :bigint           not null, primary key
 #  to_state                       :string
-#  metadata                       :text             default({})
+#  metadata                       :jsonb            not null
 #  sort_key                       :integer
 #  manifestation_checkout_stat_id :bigint
 #  created_at                     :datetime         not null

--- a/app/models/manifestation_reserve_stat_transition.rb
+++ b/app/models/manifestation_reserve_stat_transition.rb
@@ -1,7 +1,4 @@
 class ManifestationReserveStatTransition < ApplicationRecord
-  include Statesman::Adapters::ActiveRecordTransition
-
-  
   belongs_to :manifestation_reserve_stat, inverse_of: :manifestation_reserve_stat_transitions
 end
 
@@ -11,7 +8,7 @@ end
 #
 #  id                            :bigint           not null, primary key
 #  to_state                      :string
-#  metadata                      :text             default({})
+#  metadata                      :jsonb            not null
 #  sort_key                      :integer
 #  manifestation_reserve_stat_id :bigint
 #  created_at                    :datetime         not null

--- a/app/models/message_transition.rb
+++ b/app/models/message_transition.rb
@@ -1,6 +1,4 @@
 class MessageTransition < ApplicationRecord
-  include Statesman::Adapters::ActiveRecordTransition
-  
   belongs_to :message, inverse_of: :message_transitions
 end
 
@@ -10,7 +8,7 @@ end
 #
 #  id          :bigint           not null, primary key
 #  to_state    :string
-#  metadata    :text             default({})
+#  metadata    :jsonb            not null
 #  sort_key    :integer
 #  message_id  :bigint
 #  created_at  :datetime         not null

--- a/app/models/order_list_transition.rb
+++ b/app/models/order_list_transition.rb
@@ -1,7 +1,4 @@
 class OrderListTransition < ApplicationRecord
-  include Statesman::Adapters::ActiveRecordTransition
-
-  
   belongs_to :order_list, inverse_of: :order_list_transitions
 end
 
@@ -11,7 +8,7 @@ end
 #
 #  id            :bigint           not null, primary key
 #  to_state      :string
-#  metadata      :text             default({})
+#  metadata      :jsonb            not null
 #  sort_key      :integer
 #  order_list_id :integer
 #  created_at    :datetime         not null

--- a/app/models/reserve_transition.rb
+++ b/app/models/reserve_transition.rb
@@ -1,7 +1,4 @@
 class ReserveTransition < ApplicationRecord
-  include Statesman::Adapters::ActiveRecordTransition
-
-  
   belongs_to :reserve, inverse_of: :reserve_transitions
 end
 
@@ -11,7 +8,7 @@ end
 #
 #  id          :bigint           not null, primary key
 #  to_state    :string
-#  metadata    :text             default({})
+#  metadata    :jsonb            not null
 #  sort_key    :integer
 #  reserve_id  :bigint
 #  created_at  :datetime         not null

--- a/app/models/resource_export_file_transition.rb
+++ b/app/models/resource_export_file_transition.rb
@@ -1,7 +1,4 @@
 class ResourceExportFileTransition < ApplicationRecord
-  include Statesman::Adapters::ActiveRecordTransition
-
-  
   belongs_to :resource_export_file, inverse_of: :resource_export_file_transitions
 end
 
@@ -11,7 +8,7 @@ end
 #
 #  id                      :bigint           not null, primary key
 #  to_state                :string
-#  metadata                :text             default({})
+#  metadata                :jsonb            not null
 #  sort_key                :integer
 #  resource_export_file_id :bigint
 #  created_at              :datetime         not null

--- a/app/models/resource_import_file_transition.rb
+++ b/app/models/resource_import_file_transition.rb
@@ -1,7 +1,4 @@
 class ResourceImportFileTransition < ApplicationRecord
-  include Statesman::Adapters::ActiveRecordTransition
-
-  
   belongs_to :resource_import_file, inverse_of: :resource_import_file_transitions
 end
 
@@ -11,7 +8,7 @@ end
 #
 #  id                      :bigint           not null, primary key
 #  to_state                :string
-#  metadata                :text             default({})
+#  metadata                :jsonb            not null
 #  sort_key                :integer
 #  resource_import_file_id :bigint
 #  created_at              :datetime         not null

--- a/app/models/user_checkout_stat_transition.rb
+++ b/app/models/user_checkout_stat_transition.rb
@@ -1,7 +1,4 @@
 class UserCheckoutStatTransition < ApplicationRecord
-  include Statesman::Adapters::ActiveRecordTransition
-
-  
   belongs_to :user_checkout_stat, inverse_of: :user_checkout_stat_transitions
 end
 
@@ -11,7 +8,7 @@ end
 #
 #  id                    :bigint           not null, primary key
 #  to_state              :string
-#  metadata              :text             default({})
+#  metadata              :jsonb            not null
 #  sort_key              :integer
 #  user_checkout_stat_id :bigint
 #  created_at            :datetime         not null

--- a/app/models/user_export_file_transition.rb
+++ b/app/models/user_export_file_transition.rb
@@ -1,7 +1,4 @@
 class UserExportFileTransition < ApplicationRecord
-  include Statesman::Adapters::ActiveRecordTransition
-
-  
   belongs_to :user_export_file, inverse_of: :user_export_file_transitions
 end
 
@@ -11,7 +8,7 @@ end
 #
 #  id                  :bigint           not null, primary key
 #  to_state            :string
-#  metadata            :text             default({})
+#  metadata            :jsonb            not null
 #  sort_key            :integer
 #  user_export_file_id :bigint
 #  created_at          :datetime         not null

--- a/app/models/user_import_file_transition.rb
+++ b/app/models/user_import_file_transition.rb
@@ -1,7 +1,4 @@
 class UserImportFileTransition < ApplicationRecord
-  include Statesman::Adapters::ActiveRecordTransition
-
-  
   belongs_to :user_import_file, inverse_of: :user_import_file_transitions
 end
 
@@ -11,7 +8,7 @@ end
 #
 #  id                  :bigint           not null, primary key
 #  to_state            :string
-#  metadata            :text             default({})
+#  metadata            :jsonb            not null
 #  sort_key            :integer
 #  user_import_file_id :bigint
 #  created_at          :datetime         not null

--- a/app/models/user_reserve_stat_transition.rb
+++ b/app/models/user_reserve_stat_transition.rb
@@ -1,7 +1,4 @@
 class UserReserveStatTransition < ApplicationRecord
-  include Statesman::Adapters::ActiveRecordTransition
-
-  
   belongs_to :user_reserve_stat, inverse_of: :user_reserve_stat_transitions
 end
 
@@ -11,7 +8,7 @@ end
 #
 #  id                   :bigint           not null, primary key
 #  to_state             :string
-#  metadata             :text             default({})
+#  metadata             :jsonb            not null
 #  sort_key             :integer
 #  user_reserve_stat_id :bigint
 #  created_at           :datetime         not null

--- a/db/migrate/20240824034303_convert_statesman_metadata_column_to_jsonb.rb
+++ b/db/migrate/20240824034303_convert_statesman_metadata_column_to_jsonb.rb
@@ -2,7 +2,7 @@ class ConvertStatesmanMetadataColumnToJsonb < ActiveRecord::Migration[7.1]
   def up
     %w(
       agent_import_file event_import_file resource_import_file user_import_file
-      resource_export_file user_export_file
+      event_export_file resource_export_file user_export_file
       manifestation_checkout_stat manifestation_reserve_stat
       user_checkout_stat user_reserve_stat bookmark_stat
       import_request message order_list reserve
@@ -17,7 +17,7 @@ class ConvertStatesmanMetadataColumnToJsonb < ActiveRecord::Migration[7.1]
   def down
     %w(
       agent_import_file event_import_file resource_import_file user_import_file
-      resource_export_file user_export_file
+      event_export_file resource_export_file user_export_file
       manifestation_checkout_stat manifestation_reserve_stat
       user_checkout_stat user_reserve_stat bookmark_stat
       import_request message order_list reserve

--- a/db/migrate/20240824034303_convert_statesman_metadata_column_to_jsonb.rb
+++ b/db/migrate/20240824034303_convert_statesman_metadata_column_to_jsonb.rb
@@ -1,0 +1,30 @@
+class ConvertStatesmanMetadataColumnToJsonb < ActiveRecord::Migration[7.1]
+  def up
+    %w(
+      agent_import_file event_import_file resource_import_file user_import_file
+      resource_export_file user_export_file
+      manifestation_checkout_stat manifestation_reserve_stat
+      user_checkout_stat user_reserve_stat bookmark_stat
+      import_request message order_list reserve
+    ).each do |name|
+      change_column_default :"#{name}_transitions", :metadata, from: '{}', to: nil
+      change_column :"#{name}_transitions", :metadata, :jsonb, using: 'metadata::text::jsonb'
+      change_column_default :"#{name}_transitions", :metadata, from: nil, to: {}
+      change_column_null :"#{name}_transitions", :metadata, false
+    end
+  end
+
+  def down
+    %w(
+      agent_import_file event_import_file resource_import_file user_import_file
+      resource_export_file user_export_file
+      manifestation_checkout_stat manifestation_reserve_stat
+      user_checkout_stat user_reserve_stat bookmark_stat
+      import_request message order_list reserve
+    ).each do |name|
+      change_column :"#{name}_transitions", :metadata, :text
+      change_column_default :"#{name}_transitions", :metadata, from: nil, to: '{]'
+      change_column_null :"#{name}_transitions", :metadata, true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_23_175740) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_24_034303) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,7 +55,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_175740) do
 
   create_table "agent_import_file_transitions", force: :cascade do |t|
     t.string "to_state"
-    t.text "metadata", default: "{}"
+    t.jsonb "metadata", default: {}, null: false
     t.integer "sort_key"
     t.bigint "agent_import_file_id"
     t.datetime "created_at", null: false
@@ -210,7 +210,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_175740) do
 
   create_table "bookmark_stat_transitions", force: :cascade do |t|
     t.string "to_state"
-    t.text "metadata", default: "{}"
+    t.jsonb "metadata", default: {}, null: false
     t.integer "sort_key"
     t.bigint "bookmark_stat_id"
     t.datetime "created_at", null: false
@@ -530,7 +530,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_175740) do
 
   create_table "event_import_file_transitions", force: :cascade do |t|
     t.string "to_state"
-    t.text "metadata", default: "{}"
+    t.jsonb "metadata", default: {}, null: false
     t.integer "sort_key"
     t.bigint "event_import_file_id"
     t.datetime "created_at", null: false
@@ -640,7 +640,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_175740) do
 
   create_table "import_request_transitions", force: :cascade do |t|
     t.string "to_state"
-    t.text "metadata", default: "{}"
+    t.jsonb "metadata", default: {}, null: false
     t.integer "sort_key"
     t.bigint "import_request_id"
     t.datetime "created_at", null: false
@@ -907,7 +907,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_175740) do
 
   create_table "manifestation_checkout_stat_transitions", force: :cascade do |t|
     t.string "to_state"
-    t.text "metadata", default: "{}"
+    t.jsonb "metadata", default: {}, null: false
     t.integer "sort_key"
     t.bigint "manifestation_checkout_stat_id"
     t.datetime "created_at", null: false
@@ -974,7 +974,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_175740) do
 
   create_table "manifestation_reserve_stat_transitions", force: :cascade do |t|
     t.string "to_state"
-    t.text "metadata", default: "{}"
+    t.jsonb "metadata", default: {}, null: false
     t.integer "sort_key"
     t.bigint "manifestation_reserve_stat_id"
     t.datetime "created_at", null: false
@@ -1075,7 +1075,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_175740) do
 
   create_table "message_transitions", force: :cascade do |t|
     t.string "to_state"
-    t.text "metadata", default: "{}"
+    t.jsonb "metadata", default: {}, null: false
     t.integer "sort_key"
     t.bigint "message_id"
     t.datetime "created_at", null: false
@@ -1170,7 +1170,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_175740) do
 
   create_table "order_list_transitions", force: :cascade do |t|
     t.string "to_state"
-    t.text "metadata", default: "{}"
+    t.jsonb "metadata", default: {}, null: false
     t.integer "sort_key"
     t.integer "order_list_id"
     t.datetime "created_at", null: false
@@ -1400,7 +1400,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_175740) do
 
   create_table "reserve_transitions", force: :cascade do |t|
     t.string "to_state"
-    t.text "metadata", default: "{}"
+    t.jsonb "metadata", default: {}, null: false
     t.integer "sort_key"
     t.bigint "reserve_id"
     t.datetime "created_at", null: false
@@ -1435,7 +1435,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_175740) do
 
   create_table "resource_export_file_transitions", force: :cascade do |t|
     t.string "to_state"
-    t.text "metadata", default: "{}"
+    t.jsonb "metadata", default: {}, null: false
     t.integer "sort_key"
     t.bigint "resource_export_file_id"
     t.datetime "created_at", null: false
@@ -1459,7 +1459,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_175740) do
 
   create_table "resource_import_file_transitions", force: :cascade do |t|
     t.string "to_state"
-    t.text "metadata", default: "{}"
+    t.jsonb "metadata", default: {}, null: false
     t.integer "sort_key"
     t.bigint "resource_import_file_id"
     t.datetime "created_at", null: false
@@ -1805,7 +1805,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_175740) do
 
   create_table "user_checkout_stat_transitions", force: :cascade do |t|
     t.string "to_state"
-    t.text "metadata", default: "{}"
+    t.jsonb "metadata", default: {}, null: false
     t.integer "sort_key"
     t.bigint "user_checkout_stat_id"
     t.datetime "created_at", null: false
@@ -1830,7 +1830,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_175740) do
 
   create_table "user_export_file_transitions", force: :cascade do |t|
     t.string "to_state"
-    t.text "metadata", default: "{}"
+    t.jsonb "metadata", default: {}, null: false
     t.integer "sort_key"
     t.bigint "user_export_file_id"
     t.datetime "created_at", null: false
@@ -1899,7 +1899,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_175740) do
 
   create_table "user_import_file_transitions", force: :cascade do |t|
     t.string "to_state"
-    t.text "metadata", default: "{}"
+    t.jsonb "metadata", default: {}, null: false
     t.integer "sort_key"
     t.bigint "user_import_file_id"
     t.datetime "created_at", null: false
@@ -1938,7 +1938,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_175740) do
 
   create_table "user_reserve_stat_transitions", force: :cascade do |t|
     t.string "to_state"
-    t.text "metadata", default: "{}"
+    t.jsonb "metadata", default: {}, null: false
     t.integer "sort_key"
     t.bigint "user_reserve_stat_id"
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -505,7 +505,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_24_034303) do
 
   create_table "event_export_file_transitions", force: :cascade do |t|
     t.string "to_state"
-    t.text "metadata", default: "{}"
+    t.jsonb "metadata", default: {}, null: false
     t.integer "sort_key"
     t.bigint "event_export_file_id"
     t.datetime "created_at", null: false

--- a/spec/fixtures/order_list_transitions.yml
+++ b/spec/fixtures/order_list_transitions.yml
@@ -23,7 +23,7 @@ order_list_transition_00003:
 #
 #  id            :bigint           not null, primary key
 #  to_state      :string
-#  metadata      :text             default({})
+#  metadata      :jsonb            not null
 #  sort_key      :integer
 #  order_list_id :integer
 #  created_at    :datetime         not null

--- a/spec/fixtures/reserve_transitions.yml
+++ b/spec/fixtures/reserve_transitions.yml
@@ -95,7 +95,7 @@ reserve_transition_00015:
 #
 #  id          :bigint           not null, primary key
 #  to_state    :string
-#  metadata    :text             default({})
+#  metadata    :jsonb            not null
 #  sort_key    :integer
 #  reserve_id  :bigint
 #  created_at  :datetime         not null


### PR DESCRIPTION
1.4系以降ではPostgreSQLのみを使用しているため、JSONB型を利用できる。  
https://github.com/gocardless/statesman?tab=readme-ov-file#using-postgresql-json-column