### PR TITLE
非同期処理用のリンクのラベルを追加

### DIFF
--- a/app/views/agent_import_files/show.html.erb
+++ b/app/views/agent_import_files/show.html.erb
@@ -67,7 +67,7 @@
     <li><%= link_to t('activerecord.models.agent_import_result'), agent_import_results_path(agent_import_file_id: @agent_import_file.id) -%></li>
     <li><%= back_to_index(flash[:page_info]) -%></li>
     <% if current_user.has_role?('Administrator') %>
-      <li><%= link_to 'Queue', mission_control_jobs_path %></li>
+      <li><%= link_to t('page.background_job'), mission_control_jobs_path %></li>
     <% end %>
   </ul>
   <% end %>

--- a/app/views/event_export_files/show.html.erb
+++ b/app/views/event_export_files/show.html.erb
@@ -30,7 +30,7 @@
   <ul>
     <li><%= back_to_index(flash[:page_info]) -%></li>
     <% if current_user.has_role?('Administrator') %>
-      <li><%= link_to 'Queue', mission_control_jobs_path %></li>
+      <li><%= link_to t('page.background_job'), mission_control_jobs_path %></li>
     <% end %>
   </ul>
 </div>

--- a/app/views/event_import_files/show.html.erb
+++ b/app/views/event_import_files/show.html.erb
@@ -78,7 +78,7 @@
   <ul>
     <li><%= back_to_index(flash[:page_info]) -%></li>
     <% if current_user.has_role?('Administrator') %>
-      <li><%= link_to 'Queue', mission_control_jobs_path %></li>
+      <li><%= link_to t('page.background_job'), mission_control_jobs_path %></li>
     <% end %>
   </ul>
   <% end %>

--- a/app/views/page/configuration.html.erb
+++ b/app/views/page/configuration.html.erb
@@ -131,7 +131,7 @@
     <div class="config_box">
       <ul>
         <% if current_user.has_role?('Administrator') %>
-          <li><%= link_to 'Queue', mission_control_jobs_path %></li>
+          <li><%= link_to t('page.background_job'), mission_control_jobs_path %></li>
           <li><%= link_to t('page.system_information'), page_system_information_path %></li>
         <% end %>
       </ul>

--- a/app/views/resource_export_files/show.html.erb
+++ b/app/views/resource_export_files/show.html.erb
@@ -30,7 +30,7 @@
   <ul>
     <li><%= back_to_index(flash[:page_info]) -%></li>
     <% if current_user.has_role?('Administrator') %>
-      <li><%= link_to 'Queue', mission_control_jobs_path %></li>
+      <li><%= link_to t('page.background_job'), mission_control_jobs_path %></li>
     <% end %>
   </ul>
 </div>

--- a/app/views/resource_import_files/show.html.erb
+++ b/app/views/resource_import_files/show.html.erb
@@ -82,7 +82,7 @@
   <ul>
     <li><%= back_to_index(flash[:page_info]) -%></li>
     <% if current_user.has_role?('Administrator') %>
-      <li><%= link_to 'Queue', mission_control_jobs_path %></li>
+      <li><%= link_to t('page.background_job'), mission_control_jobs_path %></li>
     <% end %>
   </ul>
   <% end %>

--- a/app/views/user_export_files/show.html.erb
+++ b/app/views/user_export_files/show.html.erb
@@ -30,7 +30,7 @@
   <ul>
     <li><%= back_to_index(flash[:page_info]) -%></li>
     <% if current_user.has_role?('Administrator') %>
-      <li><%= link_to 'Queue', mission_control_jobs_path %></li>
+      <li><%= link_to t('page.background_job'), mission_control_jobs_path %></li>
     <% end %>
   </ul>
 </div>

--- a/app/views/user_import_files/show.html.erb
+++ b/app/views/user_import_files/show.html.erb
@@ -78,7 +78,7 @@
   <ul>
     <li><%= back_to_index(flash[:page_info]) -%></li>
     <% if current_user.has_role?('Administrator') %>
-      <li><%= link_to 'Queue', mission_control_jobs_path %></li>
+      <li><%= link_to t('page.background_job'), mission_control_jobs_path %></li>
     <% end %>
   </ul>
   <% end %>

--- a/config/locales/enju_leaf_en.yml
+++ b/config/locales/enju_leaf_en.yml
@@ -296,6 +296,7 @@ en:
     delegated: Delegated
     impersonate: "Impersonate"
     stop_impersonating: "Back to %{username}"
+    background_job: Background job
   title:
     index: "index"
     show: "show"

--- a/config/locales/enju_leaf_ja.yml
+++ b/config/locales/enju_leaf_ja.yml
@@ -281,6 +281,7 @@ ja:
     delegated: 代理
     impersonate: "ログインユーザを切り替える"
     stop_impersonating: "%{username}に戻る"
+    background_job: 非同期処理
   title:
     index: "一覧"
     show: "表示"


### PR DESCRIPTION
Mission Controlの画面へのリンク`/jobs`の文字列を設定しています。