### PR TITLE
erms_urlの設定を削除

### DIFF
--- a/app/controllers/library_groups_controller.rb
+++ b/app/controllers/library_groups_controller.rb
@@ -65,7 +65,7 @@ class LibraryGroupsController < ApplicationController
       :name, :display_name, :short_name, :my_networks,
       :login_banner, :note, :country_id, :admin_networks, :url,
       :max_number_of_results, :footer_banner, :email,
-      :book_jacket_source, :screenshot_generator, :erms_url,
+      :book_jacket_source, :screenshot_generator,
       :header_logo, :delete_header_logo,
       :allow_bookmark_external_url, # EnjuBookmark
       {

--- a/app/models/library_group.rb
+++ b/app/models/library_group.rb
@@ -14,7 +14,7 @@ class LibraryGroup < ApplicationRecord
   accepts_nested_attributes_for :colors, update_only: true
   store_accessor :settings,
     :book_jacket_unknown_resource,
-    :erms_url, :amazon_hostname
+    :amazon_hostname
 
   translates :login_banner, :footer_banner
   globalize_accessors

--- a/app/views/page/_menu.html.erb
+++ b/app/views/page/_menu.html.erb
@@ -121,9 +121,6 @@
           <% if defined?(EnjuSearchLog) %>
             <li><%= link_to t('activerecord.models.search_history'), search_histories_path %></li>
           <% end %>
-          <% if @library_group.erms_url %>
-            <li><%= link_to t('page.electronic_resource_management'), URI.parse(@library_group.erms_url).to_s -%></li>
-          <% end %>
           <li><%= link_to t('page.configuration'), page_configuration_path -%></li>
         </ul>
       </li>

--- a/config/locales/enju_leaf_en.yml
+++ b/config/locales/enju_leaf_en.yml
@@ -284,7 +284,6 @@ en:
     only_lowercase_letters_and_numbers_are_allowed: "is invalid. Only lowercase letters, numbers and underscore are allowed. The first character must be alphabetic."
     not_logged_in: "Not logged in"
     add_child: "Add a child"
-    electronic_resource_management: "Electronic resource management"
     system: System
     manual: Manual
     cannot_parse_yaml_header: "has an invalid YAML header. You must add a space after the header's colon."

--- a/config/locales/enju_leaf_ja.yml
+++ b/config/locales/enju_leaf_ja.yml
@@ -269,7 +269,6 @@ ja:
     only_lowercase_letters_and_numbers_are_allowed: "には英数小文字・アンダースコアのみ使用できます。最初の文字に数字は使用できません。"
     not_logged_in: "ログインしていません"
     add_child: "子を追加"
-    electronic_resource_management: 電子リソース管理
     system: システム
     manual: マニュアル
     cannot_parse_yaml_header: "のYAMLヘッダを読み込めません。ヘッダのコロンの後には、半角スペースを含める必要があります。"


### PR DESCRIPTION
かつて電子リソース管理機能を別途作成しようとして、設定のみ存在していました。作成の見込みがないため、削除します。