### PR TITLE
Cantaloupeのコンテナを更新

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       retries: 3
 
   cantaloupe:
-    image: islandora/cantaloupe:3
+    image: islandora/cantaloupe:4
     expose:
       - 8182
     restart: always


### PR DESCRIPTION
Cantaloupe 5.0.7に更新している。
https://github.com/Islandora-Devops/isle-buildkit/releases/tag/4.0.3