### PR TITLE
貸出の関係するテーブル以外のuser_idカラムにNOT NULL制約を追加

### DIFF
--- a/app/models/agent_import_file.rb
+++ b/app/models/agent_import_file.rb
@@ -222,7 +222,7 @@ end
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  parent_id                 :bigint
-#  user_id                   :bigint
+#  user_id                   :bigint           not null
 #
 # Indexes
 #

--- a/app/models/demand.rb
+++ b/app/models/demand.rb
@@ -13,7 +13,7 @@ end
 #  updated_at :datetime         not null
 #  item_id    :bigint
 #  message_id :bigint
-#  user_id    :bigint
+#  user_id    :bigint           not null
 #
 # Indexes
 #

--- a/app/models/event_export_file.rb
+++ b/app/models/event_export_file.rb
@@ -48,7 +48,7 @@ end
 #  executed_at               :datetime
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
-#  user_id                   :bigint
+#  user_id                   :bigint           not null
 #
 # Indexes
 #

--- a/app/models/event_import_file.rb
+++ b/app/models/event_import_file.rb
@@ -204,7 +204,7 @@ end
 #  default_event_category_id :bigint
 #  default_library_id        :bigint
 #  parent_id                 :bigint
-#  user_id                   :bigint
+#  user_id                   :bigint           not null
 #
 # Indexes
 #

--- a/app/models/import_request.rb
+++ b/app/models/import_request.rb
@@ -75,7 +75,7 @@ end
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  manifestation_id :bigint
-#  user_id          :bigint
+#  user_id          :bigint           not null
 #
 # Indexes
 #

--- a/app/models/inventory_file.rb
+++ b/app/models/inventory_file.rb
@@ -68,7 +68,7 @@ end
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  shelf_id               :bigint
-#  user_id                :bigint
+#  user_id                :bigint           not null
 #
 # Indexes
 #

--- a/app/models/library_group.rb
+++ b/app/models/library_group.rb
@@ -93,16 +93,10 @@ end
 #  created_at                    :datetime         not null
 #  updated_at                    :datetime         not null
 #  country_id                    :bigint
-#  user_id                       :bigint           not null
 #
 # Indexes
 #
 #  index_library_groups_on_email       (email)
 #  index_library_groups_on_lower_name  (lower((name)::text)) UNIQUE
 #  index_library_groups_on_short_name  (short_name)
-#  index_library_groups_on_user_id     (user_id)
-#
-# Foreign Keys
-#
-#  fk_rails_...  (user_id => users.id)
 #

--- a/app/models/library_group.rb
+++ b/app/models/library_group.rb
@@ -93,7 +93,7 @@ end
 #  created_at                    :datetime         not null
 #  updated_at                    :datetime         not null
 #  country_id                    :bigint
-#  user_id                       :bigint
+#  user_id                       :bigint           not null
 #
 # Indexes
 #

--- a/app/models/manifestation_checkout_stat.rb
+++ b/app/models/manifestation_checkout_stat.rb
@@ -56,7 +56,7 @@ end
 #  started_at   :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  user_id      :bigint
+#  user_id      :bigint           not null
 #
 # Indexes
 #

--- a/app/models/manifestation_reserve_stat.rb
+++ b/app/models/manifestation_reserve_stat.rb
@@ -56,7 +56,7 @@ end
 #  started_at   :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  user_id      :bigint
+#  user_id      :bigint           not null
 #
 # Indexes
 #

--- a/app/models/news_post.rb
+++ b/app/models/news_post.rb
@@ -46,7 +46,7 @@ end
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  required_role_id :bigint           default(1), not null
-#  user_id          :bigint
+#  user_id          :bigint           not null
 #
 # Indexes
 #

--- a/app/models/resource_export_file.rb
+++ b/app/models/resource_export_file.rb
@@ -47,7 +47,7 @@ end
 #  resource_export_updated_at   :datetime
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
-#  user_id                      :bigint
+#  user_id                      :bigint           not null
 #
 # Foreign Keys
 #

--- a/app/models/resource_import_file.rb
+++ b/app/models/resource_import_file.rb
@@ -919,7 +919,7 @@ end
 #  updated_at                   :datetime         not null
 #  default_shelf_id             :bigint
 #  parent_id                    :bigint
-#  user_id                      :bigint
+#  user_id                      :bigint           not null
 #
 # Indexes
 #

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -33,7 +33,7 @@ end
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  order_list_id    :bigint
-#  user_id          :bigint
+#  user_id          :bigint           not null
 #
 # Indexes
 #

--- a/app/models/user_checkout_stat.rb
+++ b/app/models/user_checkout_stat.rb
@@ -55,7 +55,7 @@ end
 #  started_at   :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  user_id      :bigint
+#  user_id      :bigint           not null
 #
 # Indexes
 #

--- a/app/models/user_export_file.rb
+++ b/app/models/user_export_file.rb
@@ -49,7 +49,7 @@ end
 #  user_export_updated_at   :datetime
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
-#  user_id                  :bigint
+#  user_id                  :bigint           not null
 #
 # Indexes
 #

--- a/app/models/user_import_file.rb
+++ b/app/models/user_import_file.rb
@@ -326,7 +326,7 @@ end
 #  updated_at               :datetime         not null
 #  default_library_id       :bigint
 #  default_user_group_id    :bigint
-#  user_id                  :bigint
+#  user_id                  :bigint           not null
 #
 # Indexes
 #

--- a/app/models/user_reserve_stat.rb
+++ b/app/models/user_reserve_stat.rb
@@ -55,7 +55,7 @@ end
 #  started_at   :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  user_id      :bigint
+#  user_id      :bigint           not null
 #
 # Indexes
 #

--- a/db/migrate/20250726135437_add_not_null_to_user_id_on_agent_import_files.rb
+++ b/db/migrate/20250726135437_add_not_null_to_user_id_on_agent_import_files.rb
@@ -1,0 +1,23 @@
+class AddNotNullToUserIdOnAgentImportFiles < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :agent_import_files, :user_id, false
+    change_column_null :bookmarks, :user_id, false
+    change_column_null :demands, :user_id, false
+    change_column_null :event_export_files, :user_id, false
+    change_column_null :event_import_files, :user_id, false
+    change_column_null :import_requests, :user_id, false
+    change_column_null :inventory_files, :user_id, false
+    change_column_null :library_groups, :user_id, false
+    change_column_null :manifestation_checkout_stats, :user_id, false
+    change_column_null :manifestation_reserve_stats, :user_id, false
+    change_column_null :news_posts, :user_id, false
+    change_column_null :purchase_requests, :user_id, false
+    change_column_null :resource_import_files, :user_id, false
+    change_column_null :resource_export_files, :user_id, false
+    change_column_null :subscriptions, :user_id, false
+    change_column_null :user_checkout_stats, :user_id, false
+    change_column_null :user_export_files, :user_id, false
+    change_column_null :user_import_files, :user_id, false
+    change_column_null :user_reserve_stats, :user_id, false
+  end
+end

--- a/db/migrate/20250726135437_add_not_null_to_user_id_on_agent_import_files.rb
+++ b/db/migrate/20250726135437_add_not_null_to_user_id_on_agent_import_files.rb
@@ -7,7 +7,6 @@ class AddNotNullToUserIdOnAgentImportFiles < ActiveRecord::Migration[7.1]
     change_column_null :event_import_files, :user_id, false
     change_column_null :import_requests, :user_id, false
     change_column_null :inventory_files, :user_id, false
-    change_column_null :library_groups, :user_id, false
     change_column_null :manifestation_checkout_stats, :user_id, false
     change_column_null :manifestation_reserve_stats, :user_id, false
     change_column_null :news_posts, :user_id, false

--- a/db/migrate/20250726140939_remove_user_id_from_library_groups.rb
+++ b/db/migrate/20250726140939_remove_user_id_from_library_groups.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromLibraryGroups < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :library_groups, :user_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_26_135437) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_26_140939) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -896,7 +896,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_26_135437) do
     t.boolean "family_name_first", default: true
     t.string "screenshot_generator"
     t.integer "pub_year_facet_range_interval", default: 10
-    t.bigint "user_id", null: false
     t.boolean "csv_charset_conversion", default: false, null: false
     t.string "header_logo_file_name"
     t.string "header_logo_content_type"
@@ -907,7 +906,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_26_135437) do
     t.index "lower((name)::text)", name: "index_library_groups_on_lower_name", unique: true
     t.index ["email"], name: "index_library_groups_on_email"
     t.index ["short_name"], name: "index_library_groups_on_short_name"
-    t.index ["user_id"], name: "index_library_groups_on_user_id"
   end
 
   create_table "licenses", force: :cascade do |t|
@@ -2061,7 +2059,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_26_135437) do
   add_foreign_key "jpno_records", "manifestations"
   add_foreign_key "lccn_records", "manifestations"
   add_foreign_key "libraries", "library_groups"
-  add_foreign_key "library_groups", "users"
   add_foreign_key "manifestation_checkout_stats", "users"
   add_foreign_key "manifestation_custom_values", "manifestation_custom_properties"
   add_foreign_key "manifestation_custom_values", "manifestations"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_26_125356) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_26_135437) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -70,7 +70,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_125356) do
     t.bigint "parent_id"
     t.string "content_type"
     t.integer "size"
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.text "note"
     t.datetime "executed_at", precision: nil
     t.string "agent_import_file_name"
@@ -472,7 +472,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_125356) do
   end
 
   create_table "demands", force: :cascade do |t|
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.bigint "item_id"
     t.bigint "message_id"
     t.datetime "created_at", null: false
@@ -523,7 +523,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_125356) do
   end
 
   create_table "event_export_files", force: :cascade do |t|
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.string "event_export_file_name"
     t.string "event_export_content_type"
     t.bigint "event_export_file_size"
@@ -551,7 +551,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_125356) do
     t.bigint "parent_id"
     t.string "content_type"
     t.integer "size"
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.text "note"
     t.datetime "executed_at", precision: nil
     t.string "event_import_file_name"
@@ -665,7 +665,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_125356) do
   create_table "import_requests", force: :cascade do |t|
     t.string "isbn"
     t.bigint "manifestation_id"
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["isbn"], name: "index_import_requests_on_isbn"
@@ -691,7 +691,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_125356) do
     t.string "filename"
     t.string "content_type"
     t.integer "size"
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.text "note"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -896,7 +896,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_125356) do
     t.boolean "family_name_first", default: true
     t.string "screenshot_generator"
     t.integer "pub_year_facet_range_interval", default: 10
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.boolean "csv_charset_conversion", default: false, null: false
     t.string "header_logo_file_name"
     t.string "header_logo_content_type"
@@ -941,7 +941,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_125356) do
     t.datetime "updated_at", null: false
     t.datetime "started_at", precision: nil
     t.datetime "completed_at", precision: nil
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_manifestation_checkout_stats_on_user_id"
   end
 
@@ -1008,7 +1008,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_125356) do
     t.datetime "updated_at", null: false
     t.datetime "started_at", precision: nil
     t.datetime "completed_at", precision: nil
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_manifestation_reserve_stats_on_user_id"
   end
 
@@ -1161,7 +1161,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_125356) do
   create_table "news_posts", force: :cascade do |t|
     t.text "title"
     t.text "body"
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.datetime "start_date", precision: nil
     t.datetime "end_date", precision: nil
     t.bigint "required_role_id", default: 1, null: false
@@ -1464,7 +1464,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_125356) do
   end
 
   create_table "resource_export_files", force: :cascade do |t|
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.string "resource_export_file_name"
     t.string "resource_export_content_type"
     t.bigint "resource_export_file_size"
@@ -1491,7 +1491,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_125356) do
     t.bigint "parent_id"
     t.string "content_type"
     t.integer "size"
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.text "note"
     t.datetime "executed_at", precision: nil
     t.string "resource_import_file_name"
@@ -1778,7 +1778,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_125356) do
   create_table "subscriptions", force: :cascade do |t|
     t.text "title", null: false
     t.text "note"
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.bigint "order_list_id"
     t.integer "subscribes_count", default: 0, null: false
     t.datetime "created_at", null: false
@@ -1847,7 +1847,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_125356) do
     t.datetime "updated_at", null: false
     t.datetime "started_at", precision: nil
     t.datetime "completed_at", precision: nil
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_user_checkout_stats_on_user_id"
   end
 
@@ -1866,7 +1866,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_125356) do
   end
 
   create_table "user_export_files", force: :cascade do |t|
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.string "user_export_file_name"
     t.string "user_export_content_type"
     t.bigint "user_export_file_size"
@@ -1934,7 +1934,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_125356) do
   end
 
   create_table "user_import_files", force: :cascade do |t|
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.text "note"
     t.datetime "executed_at", precision: nil
     t.string "user_import_file_name"
@@ -1984,7 +1984,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_125356) do
     t.datetime "updated_at", null: false
     t.datetime "started_at", precision: nil
     t.datetime "completed_at", precision: nil
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_user_reserve_stats_on_user_id"
   end
 

--- a/spec/factories/demands.rb
+++ b/spec/factories/demands.rb
@@ -15,7 +15,7 @@ end
 #  updated_at :datetime         not null
 #  item_id    :bigint
 #  message_id :bigint
-#  user_id    :bigint
+#  user_id    :bigint           not null
 #
 # Indexes
 #

--- a/spec/factories/import_requests.rb
+++ b/spec/factories/import_requests.rb
@@ -14,7 +14,7 @@ end
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  manifestation_id :bigint
-#  user_id          :bigint
+#  user_id          :bigint           not null
 #
 # Indexes
 #

--- a/spec/factories/manifestation_checkout_stats.rb
+++ b/spec/factories/manifestation_checkout_stats.rb
@@ -18,7 +18,7 @@ end
 #  started_at   :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  user_id      :bigint
+#  user_id      :bigint           not null
 #
 # Indexes
 #

--- a/spec/factories/manifestation_reserve_stats.rb
+++ b/spec/factories/manifestation_reserve_stats.rb
@@ -18,7 +18,7 @@ end
 #  started_at   :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  user_id      :bigint
+#  user_id      :bigint           not null
 #
 # Indexes
 #

--- a/spec/factories/news_posts.rb
+++ b/spec/factories/news_posts.rb
@@ -22,7 +22,7 @@ end
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  required_role_id :bigint           default(1), not null
-#  user_id          :bigint
+#  user_id          :bigint           not null
 #
 # Indexes
 #

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -16,7 +16,7 @@ end
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  order_list_id    :bigint
-#  user_id          :bigint
+#  user_id          :bigint           not null
 #
 # Indexes
 #

--- a/spec/factories/user_checkout_stats.rb
+++ b/spec/factories/user_checkout_stats.rb
@@ -18,7 +18,7 @@ end
 #  started_at   :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  user_id      :bigint
+#  user_id      :bigint           not null
 #
 # Indexes
 #

--- a/spec/factories/user_reserve_stats.rb
+++ b/spec/factories/user_reserve_stats.rb
@@ -18,7 +18,7 @@ end
 #  started_at   :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  user_id      :bigint
+#  user_id      :bigint           not null
 #
 # Indexes
 #

--- a/spec/fixtures/agent_import_files.yml
+++ b/spec/fixtures/agent_import_files.yml
@@ -30,7 +30,7 @@ agent_import_file_00003:
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  parent_id                 :bigint
-#  user_id                   :bigint
+#  user_id                   :bigint           not null
 #
 # Indexes
 #

--- a/spec/fixtures/demands.yml
+++ b/spec/fixtures/demands.yml
@@ -19,7 +19,7 @@ two:
 #  updated_at :datetime         not null
 #  item_id    :bigint
 #  message_id :bigint
-#  user_id    :bigint
+#  user_id    :bigint           not null
 #
 # Indexes
 #

--- a/spec/fixtures/event_export_files.yml
+++ b/spec/fixtures/event_export_files.yml
@@ -22,7 +22,7 @@ event_export_file_00003:
 #  executed_at               :datetime
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
-#  user_id                   :bigint
+#  user_id                   :bigint           not null
 #
 # Indexes
 #

--- a/spec/fixtures/event_import_files.yml
+++ b/spec/fixtures/event_import_files.yml
@@ -32,7 +32,7 @@ event_import_file_00003:
 #  default_event_category_id :bigint
 #  default_library_id        :bigint
 #  parent_id                 :bigint
-#  user_id                   :bigint
+#  user_id                   :bigint           not null
 #
 # Indexes
 #

--- a/spec/fixtures/import_requests.yml
+++ b/spec/fixtures/import_requests.yml
@@ -19,7 +19,7 @@ two:
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  manifestation_id :bigint
-#  user_id          :bigint
+#  user_id          :bigint           not null
 #
 # Indexes
 #

--- a/spec/fixtures/inventory_files.yml
+++ b/spec/fixtures/inventory_files.yml
@@ -27,7 +27,7 @@ inventory_file_00003:
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  shelf_id               :bigint
-#  user_id                :bigint
+#  user_id                :bigint           not null
 #
 # Indexes
 #

--- a/spec/fixtures/library_groups.yml
+++ b/spec/fixtures/library_groups.yml
@@ -48,17 +48,11 @@ one:
 #  created_at                    :datetime         not null
 #  updated_at                    :datetime         not null
 #  country_id                    :bigint
-#  user_id                       :bigint           not null
 #
 # Indexes
 #
 #  index_library_groups_on_email       (email)
 #  index_library_groups_on_lower_name  (lower((name)::text)) UNIQUE
 #  index_library_groups_on_short_name  (short_name)
-#  index_library_groups_on_user_id     (user_id)
-#
-# Foreign Keys
-#
-#  fk_rails_...  (user_id => users.id)
 #
 

--- a/spec/fixtures/library_groups.yml
+++ b/spec/fixtures/library_groups.yml
@@ -7,7 +7,6 @@ one:
   note: 
   my_networks: 0.0.0.0/0
   url: "http://localhost:3000/"
-  user_id: 1
   book_jacket_source: "google"
   screenshot_generator: "mozshot"
   settings: 

--- a/spec/fixtures/library_groups.yml
+++ b/spec/fixtures/library_groups.yml
@@ -48,7 +48,7 @@ one:
 #  created_at                    :datetime         not null
 #  updated_at                    :datetime         not null
 #  country_id                    :bigint
-#  user_id                       :bigint
+#  user_id                       :bigint           not null
 #
 # Indexes
 #

--- a/spec/fixtures/manifestation_checkout_stats.yml
+++ b/spec/fixtures/manifestation_checkout_stats.yml
@@ -26,7 +26,7 @@ two:
 #  started_at   :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  user_id      :bigint
+#  user_id      :bigint           not null
 #
 # Indexes
 #

--- a/spec/fixtures/manifestation_reserve_stats.yml
+++ b/spec/fixtures/manifestation_reserve_stats.yml
@@ -26,7 +26,7 @@ two:
 #  started_at   :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  user_id      :bigint
+#  user_id      :bigint           not null
 #
 # Indexes
 #

--- a/spec/fixtures/news_posts.yml
+++ b/spec/fixtures/news_posts.yml
@@ -28,7 +28,7 @@ news_post_00002:
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  required_role_id :bigint           default(1), not null
-#  user_id          :bigint
+#  user_id          :bigint           not null
 #
 # Indexes
 #

--- a/spec/fixtures/resource_export_files.yml
+++ b/spec/fixtures/resource_export_files.yml
@@ -22,7 +22,7 @@ resource_export_file_00003:
 #  resource_export_updated_at   :datetime
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
-#  user_id                      :bigint
+#  user_id                      :bigint           not null
 #
 # Foreign Keys
 #

--- a/spec/fixtures/resource_import_files.yml
+++ b/spec/fixtures/resource_import_files.yml
@@ -32,7 +32,7 @@ resource_import_file_00003:
 #  updated_at                   :datetime         not null
 #  default_shelf_id             :bigint
 #  parent_id                    :bigint
-#  user_id                      :bigint
+#  user_id                      :bigint           not null
 #
 # Indexes
 #

--- a/spec/fixtures/subscriptions.yml
+++ b/spec/fixtures/subscriptions.yml
@@ -21,7 +21,7 @@ subscription_00002:
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  order_list_id    :bigint
-#  user_id          :bigint
+#  user_id          :bigint           not null
 #
 # Indexes
 #

--- a/spec/fixtures/user_checkout_stats.yml
+++ b/spec/fixtures/user_checkout_stats.yml
@@ -26,7 +26,7 @@ two:
 #  started_at   :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  user_id      :bigint
+#  user_id      :bigint           not null
 #
 # Indexes
 #

--- a/spec/fixtures/user_export_files.yml
+++ b/spec/fixtures/user_export_files.yml
@@ -22,7 +22,7 @@ user_export_file_00003:
 #  user_export_updated_at   :datetime
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
-#  user_id                  :bigint
+#  user_id                  :bigint           not null
 #
 # Indexes
 #

--- a/spec/fixtures/user_import_files.yml
+++ b/spec/fixtures/user_import_files.yml
@@ -37,7 +37,7 @@ two:
 #  updated_at               :datetime         not null
 #  default_library_id       :bigint
 #  default_user_group_id    :bigint
-#  user_id                  :bigint
+#  user_id                  :bigint           not null
 #
 # Indexes
 #

--- a/spec/fixtures/user_reserve_stats.yml
+++ b/spec/fixtures/user_reserve_stats.yml
@@ -26,7 +26,7 @@ two:
 #  started_at   :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  user_id      :bigint
+#  user_id      :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/agent_import_file_spec.rb
+++ b/spec/models/agent_import_file_spec.rb
@@ -102,7 +102,7 @@ end
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  parent_id                 :bigint
-#  user_id                   :bigint
+#  user_id                   :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/event_export_file_spec.rb
+++ b/spec/models/event_export_file_spec.rb
@@ -26,7 +26,7 @@ end
 #  executed_at               :datetime
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
-#  user_id                   :bigint
+#  user_id                   :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/event_import_file_spec.rb
+++ b/spec/models/event_import_file_spec.rb
@@ -152,7 +152,7 @@ end
 #  default_event_category_id :bigint
 #  default_library_id        :bigint
 #  parent_id                 :bigint
-#  user_id                   :bigint
+#  user_id                   :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/import_request_spec.rb
+++ b/spec/models/import_request_spec.rb
@@ -35,7 +35,7 @@ end
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  manifestation_id :bigint
-#  user_id          :bigint
+#  user_id          :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/inventory_file_spec.rb
+++ b/spec/models/inventory_file_spec.rb
@@ -34,7 +34,7 @@ end
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  shelf_id               :bigint
-#  user_id                :bigint
+#  user_id                :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/library_group_spec.rb
+++ b/spec/models/library_group_spec.rb
@@ -63,7 +63,7 @@ end
 #  created_at                    :datetime         not null
 #  updated_at                    :datetime         not null
 #  country_id                    :bigint
-#  user_id                       :bigint
+#  user_id                       :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/library_group_spec.rb
+++ b/spec/models/library_group_spec.rb
@@ -63,16 +63,10 @@ end
 #  created_at                    :datetime         not null
 #  updated_at                    :datetime         not null
 #  country_id                    :bigint
-#  user_id                       :bigint           not null
 #
 # Indexes
 #
 #  index_library_groups_on_email       (email)
 #  index_library_groups_on_lower_name  (lower((name)::text)) UNIQUE
 #  index_library_groups_on_short_name  (short_name)
-#  index_library_groups_on_user_id     (user_id)
-#
-# Foreign Keys
-#
-#  fk_rails_...  (user_id => users.id)
 #

--- a/spec/models/manifestation_checkout_stat_spec.rb
+++ b/spec/models/manifestation_checkout_stat_spec.rb
@@ -27,7 +27,7 @@ end
 #  started_at   :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  user_id      :bigint
+#  user_id      :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/manifestation_reserve_stat_spec.rb
+++ b/spec/models/manifestation_reserve_stat_spec.rb
@@ -27,7 +27,7 @@ end
 #  started_at   :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  user_id      :bigint
+#  user_id      :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/news_post_spec.rb
+++ b/spec/models/news_post_spec.rb
@@ -19,7 +19,7 @@ end
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  required_role_id :bigint           default(1), not null
-#  user_id          :bigint
+#  user_id          :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/resource_export_file_spec.rb
+++ b/spec/models/resource_export_file_spec.rb
@@ -35,7 +35,7 @@ end
 #  resource_export_updated_at   :datetime
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
-#  user_id                      :bigint
+#  user_id                      :bigint           not null
 #
 # Foreign Keys
 #

--- a/spec/models/resource_import_file_spec.rb
+++ b/spec/models/resource_import_file_spec.rb
@@ -534,7 +534,7 @@ end
 #  updated_at                   :datetime         not null
 #  default_shelf_id             :bigint
 #  parent_id                    :bigint
-#  user_id                      :bigint
+#  user_id                      :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -19,7 +19,7 @@ end
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  order_list_id    :bigint
-#  user_id          :bigint
+#  user_id          :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/user_checkout_stat_spec.rb
+++ b/spec/models/user_checkout_stat_spec.rb
@@ -27,7 +27,7 @@ end
 #  started_at   :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  user_id      :bigint
+#  user_id      :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/user_export_file_spec.rb
+++ b/spec/models/user_export_file_spec.rb
@@ -25,7 +25,7 @@ end
 #  user_export_updated_at   :datetime
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
-#  user_id                  :bigint
+#  user_id                  :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/user_import_file_spec.rb
+++ b/spec/models/user_import_file_spec.rb
@@ -265,7 +265,7 @@ end
 #  updated_at               :datetime         not null
 #  default_library_id       :bigint
 #  default_user_group_id    :bigint
-#  user_id                  :bigint
+#  user_id                  :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/user_reserve_stat_spec.rb
+++ b/spec/models/user_reserve_stat_spec.rb
@@ -27,7 +27,7 @@ end
 #  started_at   :datetime
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  user_id      :bigint
+#  user_id      :bigint           not null
 #
 # Indexes
 #


### PR DESCRIPTION
baskets, checkouts, checked_items, profilesテーブル以外のuser_idカラムにNOT NULL制約を追加しています。