### PR TITLE
Amazonの書影表示ヘルパーを削除

### DIFF
--- a/app/helpers/enju_manifestation_viewer/book_jacket_helper.rb
+++ b/app/helpers/enju_manifestation_viewer/book_jacket_helper.rb
@@ -43,13 +43,6 @@ module EnjuManifestationViewer
       return nil unless manifestation
 
       case generator
-      when "amazon"
-        return nil unless LibraryGroup.site_config.amazon_hostname
-
-        book_jacket = manifestation.amazon_book_jacket
-        if book_jacket
-          link_to image_tag(book_jacket[:url], width: book_jacket[:width], height: book_jacket[:height], alt: manifestation.original_title, class: "book_jacket", itemprop: "image"), "https://#{LibraryGroup.site_config.amazon_hostname}/dp/#{book_jacket[:asin]}"
-        end
       when "google"
         render partial: "manifestations/google_book_thumbnail", locals: { manifestation: manifestation }
       when "hanmotocom"
@@ -59,18 +52,10 @@ module EnjuManifestationViewer
       end
     end
 
-    def amazon_link(asin, hostname = LibraryGroup.site_config.amazon_hostname)
-      return nil if asin.blank?
-
-      "https://#{hostname}/dp/#{asin}"
-    end
-
     def book_jacket_source_link(source = LibraryGroup.site_config.book_jacket_source)
       case source
       when "google"
         link_to "Google Books", "https://books.google.com/"
-      when "amazon"
-        link_to "Amazon Web Services", "https://aws.amazon.com/"
       end
     end
 

--- a/app/models/library_group.rb
+++ b/app/models/library_group.rb
@@ -13,8 +13,7 @@ class LibraryGroup < ApplicationRecord
   }
   accepts_nested_attributes_for :colors, update_only: true
   store_accessor :settings,
-    :book_jacket_unknown_resource,
-    :amazon_hostname
+    :book_jacket_unknown_resource
 
   translates :login_banner, :footer_banner
   globalize_accessors

--- a/spec/fixtures/library_groups.yml
+++ b/spec/fixtures/library_groups.yml
@@ -10,7 +10,7 @@ one:
   book_jacket_source: "google"
   screenshot_generator: "mozshot"
   settings: 
-    {"max_number_of_results":500,"book_jacket_unknown_resource":"unknown.png","amazon_hostname":"www.amazon.co.jp"}
+    {"max_number_of_results":500,"book_jacket_unknown_resource":"unknown.png"}
   email: admin@library.example.jp
 
 # == Schema Information

--- a/spec/helpers/book_jacket_helper_spec.rb
+++ b/spec/helpers/book_jacket_helper_spec.rb
@@ -21,10 +21,6 @@ describe EnjuManifestationViewer::BookJacketHelper do
     helper.book_jacket_tag(manifestations(:manifestation_00001)).should =~ /<div id=\"gbsthumbnail1\" class=\"book_jacket\"><\/div>/
   end
 
-  it "should generate a link to Amazon" do
-    helper.amazon_link(manifestations(:manifestation_00001).isbn_records.first.body).should =~ /https:\/\/www.amazon.co.jp\/dp\/4798002062/
-  end
-
   it "should get honmoto.com book jacket" do
     html = helper.book_jacket_tag(manifestations(:manifestation_00001), "hanmotocom")
     expect(html).to have_selector 'img[src="https://www.hanmoto.com/bd/img/9784798002064.jpg"]'


### PR DESCRIPTION
Amazonは書影の取得元としてサポートしなくなっているが、ヘルパーが残っていた。