### PR TITLE
「システムの基本的な情報の表示」画面にEnjuのバージョンを表示

### DIFF
--- a/app/views/page/system_information.html.erb
+++ b/app/views/page/system_information.html.erb
@@ -3,6 +3,7 @@
 <div id="content_list">
 
   <ul>
+    <li>Next-L Enju Leaf: <%= EnjuLeaf::VERSION %></li>
     <li>Ruby: <%= RUBY_DESCRIPTION %></li>
     <li>Environment: <%= Rails.env %></li>
     <li>Gems:


### PR DESCRIPTION
現在の画面では、Rubyと依存するgemのバージョンは表示されるが、Enjuのバージョンが表示されていないので、表示するように修正する。  
https://enju.next-l.jp/page/system_information