### PR TITLE
NDLサーチのdcterms:issuedの取得を修正

### DIFF
--- a/app/models/ndl_book.rb
+++ b/app/models/ndl_book.rb
@@ -36,7 +36,7 @@ class NdlBook
   end
 
   def issued
-    @node.at('./dcterms:issued[@xsi:type="dcterms:W3CDTF"]').try(:content).to_s
+    @node.at('./dcterms:issued')&.content
   end
 
   def isbn

--- a/spec/models/ndl_book_spec.rb
+++ b/spec/models/ndl_book_spec.rb
@@ -235,5 +235,10 @@ describe NdlBook do
       ndl_book = NdlBook.new(doc)
       ndl_book.authors[0].should eq({ id: "http://id.ndl.go.jp/auth/entity/00730574", name: "山田, 祥寛", transcription: "ヤマダ, ヨシヒロ" })
     end
+
+    it "should respond to issued", vcr: true do
+      books = NdlBook.search("Ruby")
+      expect(books[:items][0].issued).to eq "2022.2"
+    end
   end
 end


### PR DESCRIPTION
https://github.com/next-l/enju_leaf/issues/2041 の修正です。なお、月までしか入力されていない場合、インポートされるのは年のみになります。