### PR TITLE
CantaloupeとTikaのイメージを更新

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       retries: 3
 
   cantaloupe:
-    image: islandora/cantaloupe:6.3
+    image: islandora/cantaloupe:6.4
     expose:
       - 8182
     restart: always
@@ -105,7 +105,7 @@ services:
       retries: 3
 
   tika:
-    image: apache/tika:3.3.0.0
+    image: apache/tika:3.3.1.0
     expose:
       - 9998
     restart: always


### PR DESCRIPTION
`islandora/cantaloupe:6.4`と`apache/tika:3.3.1.0`に更新しています。